### PR TITLE
Speedup trait page generation

### DIFF
--- a/wqflask/wqflask/database.py
+++ b/wqflask/wqflask/database.py
@@ -13,10 +13,10 @@ db_session = scoped_session(sessionmaker(autocommit=False,
 Base = declarative_base()
 Base.query = db_session.query_property()
 
-import logging
-
-logging.basicConfig()
-logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
+#import logging
+#
+#logging.basicConfig()
+#logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 
 def init_db():
     # import all modules here that might define models so that

--- a/wqflask/wqflask/database.py
+++ b/wqflask/wqflask/database.py
@@ -13,6 +13,11 @@ db_session = scoped_session(sessionmaker(autocommit=False,
 Base = declarative_base()
 Base.query = db_session.query_property()
 
+import logging
+
+logging.basicConfig()
+logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
+
 def init_db():
     # import all modules here that might define models so that
     # they will be registered properly on the metadata.  Otherwise

--- a/wqflask/wqflask/show_trait/show_trait.py
+++ b/wqflask/wqflask/show_trait/show_trait.py
@@ -888,40 +888,7 @@ class ShowTrait(object):
             this_group = 'BXD'
 
         if this_group:
-
-            dataset_menu = []
-            print("[tape4] webqtlConfig.PUBLICTHRESH:", webqtlConfig.PUBLICTHRESH)
-            print("[tape4] type webqtlConfig.PUBLICTHRESH:", type(webqtlConfig.PUBLICTHRESH))
-            results = g.db.execute("""SELECT PublishFreeze.FullName,PublishFreeze.Name FROM
-                    PublishFreeze,InbredSet WHERE PublishFreeze.InbredSetId = InbredSet.Id
-                    and InbredSet.Name = %s and PublishFreeze.public > %s""",
-                    (this_group, webqtlConfig.PUBLICTHRESH))
-            for item in results.fetchall():
-                dataset_menu.append(dict(tissue=None,
-                                         datasets=[item]))
-
-            results = g.db.execute("""SELECT GenoFreeze.FullName,GenoFreeze.Name FROM GenoFreeze,
-                    InbredSet WHERE GenoFreeze.InbredSetId = InbredSet.Id and InbredSet.Name =
-                    %s and GenoFreeze.public > %s""",
-                    (this_group, webqtlConfig.PUBLICTHRESH))
-            for item in results.fetchall():
-                dataset_menu.append(dict(tissue=None,
-                                    datasets=[item]))
-
-            #03/09/2009: Xiaodong changed the SQL query to order by Name as requested by Rob.
-            tissues = g.db.execute("SELECT Id, Name FROM Tissue order by Name")
-            for item in tissues.fetchall():
-                tissue_id, tissue_name = item
-                data_sets = g.db.execute('''SELECT ProbeSetFreeze.FullName,ProbeSetFreeze.Name FROM ProbeSetFreeze, ProbeFreeze,
-                InbredSet WHERE ProbeSetFreeze.ProbeFreezeId = ProbeFreeze.Id and ProbeFreeze.TissueId = %s and
-                ProbeSetFreeze.public > %s and ProbeFreeze.InbredSetId = InbredSet.Id and InbredSet.Name like %s
-                order by ProbeSetFreeze.CreateTime desc, ProbeSetFreeze.AvgId ''',
-                (tissue_id, webqtlConfig.PUBLICTHRESH, "%" + this_group + "%"))
-                dataset_sub_menu = [item for item in data_sets.fetchall() if item]
-                if dataset_sub_menu:
-                    dataset_menu.append(dict(tissue=tissue_name,
-                                        datasets=dataset_sub_menu))
-
+            dataset_menu = self.dataset.group.datasets()
             dataset_menu_selected = None
             if len(dataset_menu):
                 if this_trait and this_trait.dataset:


### PR DESCRIPTION
Fixes issue #38 

This PR reduces the number of SQL queries executed for trait page generation, from ~150 to ~10.
It mostly matters when the DB is remote. (In my case the roundtrip time is 120ms, and it's no fun to wait half a minute while hundreds of queries are executing.)
