### PR TITLE
The misc/requirements.txt should not break the Docker build

### DIFF
--- a/misc/requirements.txt
+++ b/misc/requirements.txt
@@ -33,4 +33,4 @@ scipy==0.11.0
 simplejson==3.0.7
 wsgiref==0.1.2
 yolk==0.4.3
-XlsxWriter=0.7.2
+XlsxWriter==0.7.2


### PR DESCRIPTION
This should be updated in @zsloan  genenetwork2 fork, since the docker image from @lomereiter is pointing towards this file and downloading it from:

https://raw.githubusercontent.com/zsloan/genenetwork2/master/misc/requirements.txt

If this file is malformed the docker image will not install, and exit with:

```
Traceback (most recent call last):
  File "/root/ve27/local/lib/python2.7/site-packages/pip/basecommand.py", line 211, in main
    status = self.run(options, args)
  File "/root/ve27/local/lib/python2.7/site-packages/pip/commands/install.py", line 282, in run
    wheel_cache
  File "/root/ve27/local/lib/python2.7/site-packages/pip/basecommand.py", line 291, in populate_requirement_set
    wheel_cache=wheel_cache):
  File "/root/ve27/local/lib/python2.7/site-packages/pip/req/req_file.py", line 89, in parse_requirements
    for req in req_iter:
  File "/root/ve27/local/lib/python2.7/site-packages/pip/req/req_file.py", line 137, in process_line
    isolated=isolated, options=req_options, wheel_cache=wheel_cache
  File "/root/ve27/local/lib/python2.7/site-packages/pip/req/req_install.py", line 213, in from_line
    wheel_cache=wheel_cache, constraint=constraint)
  File "/root/ve27/local/lib/python2.7/site-packages/pip/req/req_install.py", line 67, in __init__
    req = pkg_resources.Requirement.parse(req)
  File "/root/ve27/local/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2980, in parse
    reqs = list(parse_requirements(s))
  File "/root/ve27/local/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2924, in parse_requirements
    "version spec")
  File "/root/ve27/local/lib/python2.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2889, in scan_list
    raise RequirementParseError(msg, line, "at", line[p:])
RequirementParseError: Expected version spec in XlsxWriter=0.7.2 at =0.7.2
```