### PR TITLE
Add missing columns to db downloaded from AWS

### DIFF
--- a/scripts/add_missing_columns.sh
+++ b/scripts/add_missing_columns.sh
@@ -1,0 +1,24 @@
+ #! /bin/bash
+ #
+ # Add missing columns to test db downloaded from:
+ # https://s3.amazonaws.com/genenetwork2/db_webqtl_s.zip
+
+ QUERY="
+ ALTER TABLE InbredSet
+ ADD Family varchar(20) AFTER FullName,
+ ADD FamilyOrder varchar(20) AFTER Family,
+ ADD MenuOrderId smallint(6) AFTER FamilyOrder,
+ ADD InbredSetCode varchar(5) AFTER MenuOrderId;
+
+ ALTER TABLE PublishXRef
+ ADD mean double AFTER DataId;
+
+ -- This takes some time
+ ALTER TABLE ProbeSet
+ ADD UniProtID varchar(20) AFTER ProteinName;
+ "
+
+ USER=gn2
+ DBNAME=db_webqtl_s
+ PASS=mysql_password
+ mysql -u"$USER" -p"$PASS" -h localhost -D "$DBNAME" -e "$QUERY"


### PR DESCRIPTION
#### Description

The zip file from the AWS S3 bucket has some missing columns, and this causes GN2 to throw assert errors because of missing columns. This PR adds the missing columns

  *Scenario: A developer sets up sql using the sql zip file and runs a bash script*

  _Given_ a developer has set up the sql tables from the zip file
  _When_ he/ she runs the script
  _Then_ missing columns are added to the db