### PR TITLE
Build/add scientific js datatables plugin

### DIFF
--- a/test/requests/link_checker.py
+++ b/test/requests/link_checker.py
@@ -89,14 +89,14 @@ def check_packaged_js_files(args_obj, parser):
         "/DataTablesExtensions/buttons/js/dataTables.buttons.min.js",
         "/DataTablesExtensions/buttonStyles/css/buttons.dataTables.min.css",
         "/DataTablesExtensions/buttons/js/dataTables.buttons.min.js",
-        "/DataTablesExtensions/plugins/sorting/natural.js",
         "/DataTablesExtensions/colResize/dataTables.colResize.js",
         "/DataTablesExtensions/colReorder/js/dataTables.colReorder.js",
         "/DataTablesExtensions/buttons/js/buttons.colVis.min.js",
         "/DataTables/js/jquery.dataTables.js",
         "/DataTablesExtensions/scroller/css/scroller.dataTables.min.css",
-        # natural.js [Datatables plugin]
+        # Datatables plugins:
         "/DataTablesExtensions/plugins/sorting/natural.js",
+        "/DataTablesExtensions/plugins/sorting/scientific.js",
     ]
 
     print("Checking links")

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -341,7 +341,7 @@
 
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="https://cdn.datatables.net/buttons/1.0.0/js/dataTables.buttons.min.js"></script>
-    <script language="javascript" type="text/javascript" src="/static/new/packages/DataTables/js/dataTables.scientific.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/scientific.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/natural.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/packages/purescript_genome_browser/js/purescript-genetics-browser.js"></script>
 

--- a/wqflask/wqflask/templates/pair_scan_results.html
+++ b/wqflask/wqflask/templates/pair_scan_results.html
@@ -66,7 +66,7 @@
     <script language="javascript" type="text/javascript" src="/static/new/js_external/d3-tip.min.js"></script>
     <script language="javascript" type="text/javascript" src="/static/new/packages/DataTables/js/jquery.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
-    <script language="javascript" type="text/javascript" src="/static/new/packages/DataTables/js/dataTables.scientific.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/scientific.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/packages/DT_bootstrap/DT_bootstrap.js"></script>
     <script language="javascript" type="text/javascript" src="/static/packages/TableTools/media/js/TableTools.min.js"></script>
     <script language="javascript" type="text/javascript" src="/static/packages/underscore/underscore-min.js"></script>

--- a/wqflask/wqflask/templates/show_trait.html
+++ b/wqflask/wqflask/templates/show_trait.html
@@ -148,7 +148,7 @@
     <script type="text/javascript" src="/static/new/javascript/validation.js"></script>
 
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.js') }}"></script>
-    <script language="javascript" type="text/javascript" src="/static/new/packages/DataTables/js/dataTables.scientific.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/scientific.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/natural.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/packages/noUiSlider/nouislider.js"></script>
     <script language="javascript" type="text/javascript" src="/static/new/javascript/get_covariates_from_collection.js"></script>


### PR DESCRIPTION
#### Description

This PR replaces scientificjs datatables plugin with the ones provided from Guix.

### How should this be tested?

- The behaviour in the existing data tables should be the same

#### Any background context you want to provide

- This is the last js library wrt Datatables. The next PR will involve deleting datatables and it's extensions from git. See: https://github.com/genenetwork/genenetwork2/pull/394/commits/9745a992fc82aabfe75798d68570f96725cc5fc1

#### What are the relevant pivotal tracker stories?

N/A

#### Screenshots (if appropriate)

N/A

#### Questions

N/A