### PR TITLE
Use d3-tip from guix

### DIFF
--- a/test/requests/link_checker.py
+++ b/test/requests/link_checker.py
@@ -99,6 +99,7 @@ def check_packaged_js_files(args_obj, parser):
         "/DataTablesExtensions/plugins/sorting/scientific.js",
         # Other js libraries
         "/chroma/chroma.min.js"
+        "/d3-tip/d3-tip.js"
     ]
 
     print("Checking links")

--- a/wqflask/wqflask/templates/comparison_bar_chart.html
+++ b/wqflask/wqflask/templates/comparison_bar_chart.html
@@ -29,7 +29,7 @@
     </script>
 
     <script language="javascript" type="text/javascript" src="http://d3js.org/d3.v3.min.js"></script>
-    <script language="javascript" type="text/javascript" src="/static/new/js_external/d3-tip.min.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename=d3-tip/d3-tip.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/javascript/panelutil.js"></script>
     <script language="javascript" type="text/javascript" src="/static/packages/underscore/underscore-min.js"></script>
     <script type="text/javascript" src="/static/new/js_external/plotly-latest.min.js"></script>

--- a/wqflask/wqflask/templates/corr_scatterplot.html
+++ b/wqflask/wqflask/templates/corr_scatterplot.html
@@ -348,7 +348,7 @@
     </script>
     <script language="javascript" type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
     <script language="javascript" type="text/javascript" src="/static/packages/underscore/underscore-min.js"></script>
-    <script language="javascript" type="text/javascript" src="/static/new/js_external/d3-tip.min.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename=d3-tip/d3-tip.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/js_external/jscolor.js"></script>
     <script language="javascript" type="text/javascript" src="/static/new/javascript/panelutil.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.js') }}"></script>

--- a/wqflask/wqflask/templates/correlation_matrix.html
+++ b/wqflask/wqflask/templates/correlation_matrix.html
@@ -128,7 +128,7 @@
     </script>
 
     <script type="text/javascript" src="http://d3js.org/d3.v3.min.js"></script>
-    <script type="text/javascript" src="/static/new/js_external/d3-tip.min.js"></script>
+    <script type="text/javascript" src="{{ url_for('js', filename=d3-tip/d3-tip.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/packages/underscore/underscore-min.js"></script>
     <script language="javascript" type="text/javascript" src="/static/new/js_external/md5.min.js"></script>
     <script type="text/javascript" src="/static/new/javascript/panelutil.js"></script>

--- a/wqflask/wqflask/templates/heatmap.html
+++ b/wqflask/wqflask/templates/heatmap.html
@@ -33,7 +33,7 @@
     </script>
 
     <script language="javascript" type="text/javascript" src="http://d3js.org/d3.v3.min.js"></script>
-    <script language="javascript" type="text/javascript" src="/static/new/js_external/d3-tip.min.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename=d3-tip/d3-tip.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/javascript/panelutil.js"></script>
     <script language="javascript" type="text/javascript" src="/static/new/javascript/lodheatmap.js"></script>
     <script language="javascript" type="text/javascript" src="/static/new/javascript/lod_chart.js"></script>

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -336,7 +336,7 @@
     <script type="text/javascript" src="/static/new/js_external/md5.min.js"></script>
     <script type="text/javascript" src="/static/new/js_external/underscore-min.js"></script>
     <script type="text/javascript" src="/static/new/js_external/underscore.string.min.js"></script>
-    <script type="text/javascript" src="/static/new/js_external/d3-tip.min.js"></script>
+    <script type="text/javascript" src="{{ url_for('js', filename=d3-tip/d3-tip.js') }}"></script>
     <script type="text/javascript" src="/static/new/js_external/plotly-latest.min.js"></script>
 
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>

--- a/wqflask/wqflask/templates/pair_scan_results.html
+++ b/wqflask/wqflask/templates/pair_scan_results.html
@@ -63,7 +63,7 @@
 {% block js %}  
 
     <script language="javascript" type="text/javascript" src="http://d3js.org/d3.v3.min.js"></script>
-    <script language="javascript" type="text/javascript" src="/static/new/js_external/d3-tip.min.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename=d3-tip/d3-tip.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/packages/DataTables/js/jquery.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/scientific.js') }}"></script>

--- a/wqflask/wqflask/templates/show_trait.html
+++ b/wqflask/wqflask/templates/show_trait.html
@@ -132,7 +132,7 @@
     <script type="text/javascript" src="https://d3js.org/d3.v3.min.js"></script>
     <script type="text/javascript" src="/static/new/js_external/underscore-min.js"></script>
     <script type="text/javascript" src="/static/new/js_external/underscore.string.min.js"></script>
-    <script type="text/javascript" src="/static/new/js_external/d3-tip.min.js"></script>
+    <script type="text/javascript" src="{{ url_for('js', filename=d3-tip/d3-tip.js') }}"></script>
     <script type="text/javascript" src="/static/new/js_external/jstat.min.js"></script>
     <script type="text/javascript" src="/static/new/js_external/shapiro-wilk.js"></script>
     <script type="text/javascript" src="/static/new/js_external/plotly-latest.min.js"></script>


### PR DESCRIPTION
#### Description

Use `d3-tip.js` (version 0.9.1) from guix.

#### How should this be tested?

- Run [Mechanical Rob](https://github.com/genenetwork/genenetwork2#mechanical-rob) to see whether all files are being fetched correctly
- Try running gn2. The behaviour of d3-tip.js should be the same as before.

#### Any background context you want to provide?

- This is part of the effort to decouple Javascript from the project
- Cherry picked https://github.com/genenetwork/genenetwork2/pull/394/commits/553f422e9e73e8ff84c79189059fef0c09fa86c1 from: #394 

#### What are the relevant pivotal tracker stories?

N/A

#### Screenshots (if appropriate)

N/A

#### Questions

N/A
