### PR TITLE
Build/use md5 js from guix

### DIFF
--- a/test/requests/link_checker.py
+++ b/test/requests/link_checker.py
@@ -104,6 +104,7 @@ def check_packaged_js_files(args_obj, parser):
         "/js_alt/underscore.min.js",
         "/nvd3/nv.d3.min.css",
         "/qtip2/jquery.qtip.min.js",
+        "/js_alt/md5.min.js",
     ]
 
     print("Checking links")

--- a/wqflask/wqflask/templates/collections/view.html
+++ b/wqflask/wqflask/templates/collections/view.html
@@ -165,7 +165,7 @@
 
 {% block js %}
     <script language="javascript" type="text/javascript" src="/static/new/js_external/jszip.min.js"></script>
-    <script language="javascript" type="text/javascript" src="/static/new/js_external/md5.min.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='js_alt/md5.min.js') }}"></script>
     <script type="text/javascript" src="/static/new/javascript/search_results.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/natural.js') }}"></script>

--- a/wqflask/wqflask/templates/correlation_matrix.html
+++ b/wqflask/wqflask/templates/correlation_matrix.html
@@ -130,7 +130,7 @@
     <script type="text/javascript" src="{{ url_for('js', filename='d3js/d3.min.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('js', filename='d3-tip/d3-tip.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/packages/underscore/underscore-min.js"></script>
-    <script language="javascript" type="text/javascript" src="/static/new/js_external/md5.min.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='js_alt/md5.min.js') }}"></script>
     <script type="text/javascript" src="/static/new/javascript/panelutil.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='chroma/chroma.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/javascript/loadings_plot.js"></script>

--- a/wqflask/wqflask/templates/correlation_page.html
+++ b/wqflask/wqflask/templates/correlation_page.html
@@ -200,7 +200,7 @@
 {% endblock %}
 
 {% block js %}
-    <script type="text/javascript" src="/static/new/js_external/md5.min.js"></script>
+    <script type="text/javascript" src="{{ url_for('js', filename='js_alt/md5.min.js') }}"></script>
     <script type="text/javascript" src="/static/new/javascript/search_results.js"></script>
 
     <script language="javascript" type="text/javascript" src="/static/new/js_external/jszip.min.js"></script>

--- a/wqflask/wqflask/templates/gsearch_gene.html
+++ b/wqflask/wqflask/templates/gsearch_gene.html
@@ -46,7 +46,7 @@
 {% endblock %}
 
 {% block js %}
-    <script language="javascript" type="text/javascript" src="/static/new/js_external/md5.min.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='js_alt/md5.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/javascript/search_results.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/js_external/jszip.min.js"></script>

--- a/wqflask/wqflask/templates/gsearch_pheno.html
+++ b/wqflask/wqflask/templates/gsearch_pheno.html
@@ -46,7 +46,7 @@
 {% endblock %}
 
 {% block js %}
-    <script language="javascript" type="text/javascript" src="/static/new/js_external/md5.min.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='js_alt/md5.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/javascript/search_results.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/js_external/jszip.min.js"></script>

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -333,7 +333,7 @@
 {% block js %}  
 
     <script type="text/javascript" src="{{ url_for('js', filename='d3js/d3.min.js') }}"></script>
-    <script type="text/javascript" src="/static/new/js_external/md5.min.js"></script>
+    <script type="text/javascript" src="{{ url_for('js', filename='js_alt/md5.min.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('js', filename='js_alt/underscore.min.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('js', filename=underscore-string/underscore.string.min.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('js', filename='d3-tip/d3-tip.js') }}"></script>

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -154,7 +154,7 @@
 {% endblock %}
 
 {% block js %}
-    <script language="javascript" type="text/javascript" src="/static/new/js_external/md5.min.js"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='js_alt/md5.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="/static/new/javascript/search_results.js"></script>
 
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>


### PR DESCRIPTION
#### Description

Use `md5.min.js`(v0.7.3) provided from guix which is a simple MD5 hash function with UTF-8 encoding.

#### How should this be tested?

- Run [Mechanical Rob](https://github.com/genenetwork/genenetwork2#mechanical-rob) to see whether all files are being fetched correctly
- Try running gn2. The behaviour of md5 should be the same as before.

#### Any background context you want to provide?

This is part of the effort to decouple Javascript from the project and use files from the [GUIX_PROFILE](http://git.genenetwork.org/guix-bioinformatics/guix-bioinformatics/commit/a8849f31e257ab6f762d1b1babb029ccd0642d21)

#### What are the relevant pivotal tracker stories?

N/A

#### Screenshots (if appropriate)

N/A

#### Questions

N/A