### PR TITLE
Fix/use correct path give a path location

### DIFF
--- a/test/requests/link_checker.py
+++ b/test/requests/link_checker.py
@@ -52,6 +52,21 @@ def verify_link(link):
         if DO_FAIL:
             raise ex
 
+
+def verify_static_file(link):
+    print("verifying "+link)
+    try:
+        result = requests.get(link, timeout=20, verify=False)
+        if (result.status_code == 200 and
+                result.content.find("Error: 404 Not Found") <= 0):
+            print(link+" ==> OK")
+        else:
+            print("ERROR: link {}".format(link))
+            raise Exception("Failed verify")
+    except ConnectionError as ex:
+        print("ERROR: ", link, ex)
+
+
 def check_page(host, start_url):
     print("")
     print("Checking links host "+host+" in page `"+start_url+"`")
@@ -85,28 +100,28 @@ def check_packaged_js_files(args_obj, parser):
     host = args_obj.host
     js_files = [
         # Datatables Extensions:
-        "/DataTablesExtensions/buttonsBootstrap/css/buttons.bootstrap.css",
-        "/DataTablesExtensions/buttons/js/dataTables.buttons.min.js",
-        "/DataTablesExtensions/buttonStyles/css/buttons.dataTables.min.css",
-        "/DataTablesExtensions/buttons/js/dataTables.buttons.min.js",
-        "/DataTablesExtensions/colResize/dataTables.colResize.js",
-        "/DataTablesExtensions/colReorder/js/dataTables.colReorder.js",
-        "/DataTablesExtensions/buttons/js/buttons.colVis.min.js",
-        "/DataTables/js/jquery.dataTables.js",
-        "/DataTablesExtensions/scroller/css/scroller.dataTables.min.css",
+        "/css/DataTablesExtensions/buttonsBootstrap/css/buttons.bootstrap.css",
+        "/js/DataTablesExtensions/buttons/js/dataTables.buttons.min.js",
+        "/css/DataTablesExtensions/buttonStyles/css/buttons.dataTables.min.css",
+        "/js/DataTablesExtensions/buttons/js/dataTables.buttons.min.js",
+        "/js/DataTablesExtensions/colResize/dataTables.colResize.js",
+        "/js/DataTablesExtensions/colReorder/js/dataTables.colReorder.js",
+        "/js/DataTablesExtensions/buttons/js/buttons.colVis.min.js",
+        "/js/DataTables/js/jquery.dataTables.js",
+        "/css/DataTablesExtensions/scroller/css/scroller.dataTables.min.css",
         # Datatables plugins:
-        "/DataTablesExtensions/plugins/sorting/natural.js",
-        "/DataTablesExtensions/plugins/sorting/scientific.js",
+        "/js/DataTablesExtensions/plugins/sorting/natural.js",
+        "/js/DataTablesExtensions/plugins/sorting/scientific.js",
         # Other js libraries
-        "/chroma/chroma.min.js",
-        "/d3-tip/d3-tip.js",
-        "/d3js/d3.min.js",
-        "/js_alt/underscore.min.js",
-        "/nvd3/nv.d3.min.css",
-        "/qtip2/jquery.qtip.min.js",
-        "/js_alt/md5.min.js",
+        "/js/chroma/chroma.min.js",
+        "/js/d3-tip/d3-tip.js",
+        "/js/d3js/d3.min.js",
+        "/js/js_alt/underscore.min.js",
+        "/js/nvd3/nv.d3.min.css",
+        "/js/qtip2/jquery.qtip.min.js",
+        "/js/js_alt/md5.min.js",
     ]
 
     print("Checking links")
     for link in js_files:
-        verify_link(host+link)
+        verify_static_file(host+link)

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -175,13 +175,24 @@ def tmp_page(img_path):
     return render_template("show_image.html",
                             img_base64 = bytesarray )
 
+
 @app.route("/js/<path:filename>")
 def js(filename):
-    return send_from_directory(JS_GUIX_PATH, filename)
+    js_path = JS_GUIX_PATH
+    name = filename
+    if 'js_alt/' in filename:
+        js_path = js_path.replace('genenetwork2/javascript', 'javascript')
+        name = name.replace('js_alt/', '')
+    return send_from_directory(js_path, name)
 
 @app.route("/css/<path:filename>")
 def css(filename):
-    return send_from_directory(CSS_PATH, filename)
+    js_path = JS_GUIX_PATH
+    name = filename
+    if 'js_alt/' in filename:
+        js_path = js_path.replace('genenetwork2/javascript', 'javascript')
+        name = name.replace('js_alt/', '')
+    return send_from_directory(js_path, name)
 
 @app.route("/twitter/<path:filename>")
 def twitter(filename):


### PR DESCRIPTION
#### Description

This PR:

- Fixes false positives in link_checker in Mechanical Rob tests when checking that static files are being fetched. The false positives come about because we checked for a *200*(error pages are *200*).
- Fetches files correctly in paths prefixed by "js_alt"

#### How should this be tested?

- Run Mechanical Rob
- Try loading:
    - *localhost:5004/js_alt/md5.min.js*; or
    - *localhost:5004/js_alt/underscore.min.js*
from the browser. The raw js file(instead of an error) should be shown.
- Try creating a collection. MD5 should now be working(with latest profile)

#### Any background context you want to provide?

In the GUIX_PROFILE, we store js files in 2 places: 
- *GN2_PROFILE/share/javascript*; and
- *GN2_PROFILE/share/genenetwork2/javascript*
The former should be the one referred to when using *js_alt*

#### What are the relevant pivotal tracker stories?

- closes https://github.com/genenetwork/genenetwork2/issues/436
- [This](http://git.genenetwork.org/guix-bioinformatics/guix-bioinformatics/commit/a293559ea741ba209bf4676608a4fb16c07cfab5) resolves https://github.com/genenetwork/genenetwork2/issues/435

#### Screenshots (if appropriate)

N/A

#### Questions

N/A
