### PR TITLE
Bug/fix casting error

### DIFF
--- a/wqflask/base/trait.py
+++ b/wqflask/base/trait.py
@@ -599,10 +599,9 @@ def retrieve_trait_info(trait, dataset, get_qtl_info=False):
                         trait.locus = trait.locus_chr = trait.locus_mb = trait.additive = ""
                 else:
                     trait.locus = trait.lrs = trait.additive = ""
-
-            if (dataset.type == 'Publish' or dataset.type == "ProbeSet") and trait.locus_chr != "" and trait.locus_mb != "":
+            if (dataset.type == 'Publish' or dataset.type == "ProbeSet") and str(trait.locus_chr or "") != "" and str(trait.locus_mb or "") != "":
                 trait.LRS_location_repr = LRS_location_repr = 'Chr%s: %.6f' % (trait.locus_chr, float(trait.locus_mb))
-                if trait.lrs != "":
+                if str(trait.lrs or "") != "":
                     trait.LRS_score_repr = LRS_score_repr = '%3.1f' % trait.lrs
     else:
         raise KeyError, `trait.name`+' information is not found in the database.'

--- a/wqflask/tests/base/test_trait.py
+++ b/wqflask/tests/base/test_trait.py
@@ -99,3 +99,137 @@ class TestRetrieveTraitInfo(unittest.TestCase):
                          "ファイルを画面毎に見て行くには、次のコマンドを使います。".decode('utf-8'))
         self.assertEqual(test_trait.authors,
                          "Jane Doe かいと".decode('utf-8'))
+
+    @mock.patch('base.trait.requests.get')
+    @mock.patch('base.trait.g')
+    @mock.patch('base.trait.get_resource_id')
+    def test_retrieve_trait_info_with_non_empty_lrs(self,
+                                                    resource_id_mock,
+                                                    g_mock,
+                                                    requests_mock):
+        """Test """
+        resource_id_mock.return_value = 1
+        g_mock.db.execute.return_value.fetchone = mock.Mock()
+        g_mock.db.execute.return_value.fetchone.side_effect = [
+            [1, 2, 3, 4],  # trait_info = g.db.execute(query).fetchone()
+            [1, 2.37, 3, 4, 5],  # trait_qtl = g.db.execute(query).fetchone()
+            [2.7333, 2.1204]  # trait_info = g.db.execute(query).fetchone()
+        ]
+        requests_mock.return_value = None
+
+        mock_dataset = mock.MagicMock()
+        type(mock_dataset).display_fields = mock.PropertyMock(
+            return_value=["a", "b", "c", "d"])
+        type(mock_dataset).type = "ProbeSet"
+        type(mock_dataset).name = "RandomName"
+
+        mock_trait = MockTrait(
+            dataset=mock_dataset,
+            pre_publication_description="test_string"
+        )
+        trait_attrs = {
+            "description": "some description",
+            "probe_target_description": "some description",
+            "cellid": False,
+            "chr": 2.733,
+            "mb": 2.1204
+        }
+
+        for key, val in list(trait_attrs.items()):
+            setattr(mock_trait, key, val)
+        test_trait = retrieve_trait_info(trait=mock_trait,
+                                         dataset=mock_dataset,
+                                         get_qtl_info=True)
+        self.assertEqual(test_trait.LRS_score_repr,
+                         "2.4")
+
+    @mock.patch('base.trait.requests.get')
+    @mock.patch('base.trait.g')
+    @mock.patch('base.trait.get_resource_id')
+    def test_retrieve_trait_info_with_empty_lrs_field(self,
+                                                      resource_id_mock,
+                                                      g_mock,
+                                                      requests_mock):
+        """Test retrieve trait info with empty lrs field"""
+        resource_id_mock.return_value = 1
+        g_mock.db.execute.return_value.fetchone = mock.Mock()
+        g_mock.db.execute.return_value.fetchone.side_effect = [
+            [1, 2, 3, 4],  # trait_info = g.db.execute(query).fetchone()
+            [1, None, 3, 4, 5],  # trait_qtl = g.db.execute(query).fetchone()
+            [2, 3]  # trait_info = g.db.execute(query).fetchone()
+        ]
+        requests_mock.return_value = None
+
+        mock_dataset = mock.MagicMock()
+        type(mock_dataset).display_fields = mock.PropertyMock(
+            return_value=["a", "b", "c", "d"])
+        type(mock_dataset).type = "ProbeSet"
+        type(mock_dataset).name = "RandomName"
+
+        mock_trait = MockTrait(
+            dataset=mock_dataset,
+            pre_publication_description="test_string"
+        )
+        trait_attrs = {
+            "description": "some description",
+            "probe_target_description": "some description",
+            "cellid": False,
+            "chr": 2.733,
+            "mb": 2.1204
+        }
+
+        for key, val in list(trait_attrs.items()):
+            setattr(mock_trait, key, val)
+        test_trait = retrieve_trait_info(trait=mock_trait,
+                                         dataset=mock_dataset,
+                                         get_qtl_info=True)
+        self.assertEqual(test_trait.LRS_score_repr,
+                         "N/A")
+        self.assertEqual(test_trait.LRS_location_repr,
+                         "Chr2: 3.000000")
+
+    @mock.patch('base.trait.requests.get')
+    @mock.patch('base.trait.g')
+    @mock.patch('base.trait.get_resource_id')
+    def test_retrieve_trait_info_with_empty_chr_field(self,
+                                                      resource_id_mock,
+                                                      g_mock,
+                                                      requests_mock):
+        """Test retrieve trait info with empty chr field"""
+        resource_id_mock.return_value = 1
+        g_mock.db.execute.return_value.fetchone = mock.Mock()
+        g_mock.db.execute.return_value.fetchone.side_effect = [
+            [1, 2, 3, 4],  # trait_info = g.db.execute(query).fetchone()
+            [1, 2, 3, 4, 5],  # trait_qtl = g.db.execute(query).fetchone()
+            [None, 3]  # trait_info = g.db.execute(query).fetchone()
+        ]
+
+        requests_mock.return_value = None
+
+        mock_dataset = mock.MagicMock()
+        type(mock_dataset).display_fields = mock.PropertyMock(
+            return_value=["a", "b", "c", "d"])
+        type(mock_dataset).type = "ProbeSet"
+        type(mock_dataset).name = "RandomName"
+
+        mock_trait = MockTrait(
+            dataset=mock_dataset,
+            pre_publication_description="test_string"
+        )
+        trait_attrs = {
+            "description": "some description",
+            "probe_target_description": "some description",
+            "cellid": False,
+            "chr": 2.733,
+            "mb": 2.1204
+        }
+
+        for key, val in list(trait_attrs.items()):
+            setattr(mock_trait, key, val)
+        test_trait = retrieve_trait_info(trait=mock_trait,
+                                         dataset=mock_dataset,
+                                         get_qtl_info=True)
+        self.assertEqual(test_trait.LRS_score_repr,
+                         "N/A")
+        self.assertEqual(test_trait.LRS_location_repr,
+                         "N/A")


### PR DESCRIPTION
#### Description

This PR:
- Fixes a bug when you try this [search](http://genenetwork.org/search?species=mouse&group=BXD&type=Brain+mRNA&dataset=UTHSC_BXD_WB_RNASeqtrim1112&search_terms_or=Kcnk9+Trappc9++Ago2+Eif2c2+Ptk2+Dennd3+Slc45a4+Gpr20+Ptp4a3+Mroh5+1810044A24Rik+&search_terms_and=&FormID=searchResult)
- Adds tests to reproduce ^^

#### How should this be tested?

- Run the unittests. See the docs.

#### Any background context you want to provide?

`(None or "")` is a short convenient way of converting None values to strings, which is basically the fix for this issue.

#### What are the relevant pivotal tracker stories?

N/A

#### Screenshots (if appropriate)
**The search:**

<img width="563" alt="Screen Shot 2020-09-27 at 10 24 46 AM" src="https://user-images.githubusercontent.com/11820306/94378669-03496180-0134-11eb-94ff-bb14c21780bb.png">

**The error:**

![image](https://user-images.githubusercontent.com/11820306/94378694-207e3000-0134-11eb-8887-b9dd3735761a.png)


#### Questions

N/A