### PR TITLE
Table sort error fix

### DIFF
--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -261,6 +261,12 @@ $(function() {
 
   let na_equivalent_vals = ["N/A", "--", ""]; //ZS: Since there are multiple values that should be treated the same as N/A
 
+  function extract_inner_text(the_string){
+    var span = document.createElement('span');
+    span.innerHTML = the_string;
+    return span.textContent || span.innerText;
+  }
+
   function sort_NAs(a, b, sort_function){
     if ( na_equivalent_vals.includes(a) && na_equivalent_vals.includes(b)) {
       return 0;
@@ -276,10 +282,10 @@ $(function() {
 
   $.extend( $.fn.dataTableExt.oSort, {
     "natural-minus-na-asc": function (a, b) {
-      return sort_NAs(a, b, naturalAsc)
+      return sort_NAs(extract_inner_text(a), extract_inner_text(b), naturalAsc)
     },
     "natural-minus-na-desc": function (a, b) {
-      return sort_NAs(a, b, naturalDesc)
+      return sort_NAs(extract_inner_text(a), extract_inner_text(b), naturalDesc)
     }
   });
 

--- a/wqflask/wqflask/templates/collections/view.html
+++ b/wqflask/wqflask/templates/collections/view.html
@@ -164,13 +164,13 @@
 {% block js %}
     <script language="javascript" type="text/javascript" src="/static/new/js_external/jszip.min.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='js_alt/md5.min.js') }}"></script>
-    <script type="text/javascript" src="/static/new/javascript/search_results.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/natural.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/colResize/dataTables.colResize.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/colReorder/js/dataTables.colReorder.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/buttons/js/dataTables.buttons.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/buttons/js/buttons.colVis.min.js') }}"></script>
+    <script type="text/javascript" src="/static/new/javascript/search_results.js"></script>
 
 
     <script language="javascript" type="text/javascript">
@@ -185,10 +185,14 @@
             console.time("Creating table");
             $('#trait_table').dataTable( {
                 "columns": [
-                    { "type": "natural", "width": 10 },
+                    {
+                        "orderDataType": "dom-checkbox",
+                        "orderSequence": [ "desc", "asc"],
+                        "width": 10
+                    },
                     { "type": "natural", "width": 50 },
                     { "type": "natural" },
-                    { "type": "natural", "width": 120 },
+                    { 'type': "natural-minus-na", "width": 120 },
                     { "type": "natural" },
                     { "type": "natural"  },
                     { "type": "natural", "width": 130 },
@@ -197,10 +201,6 @@
                     { "type": "natural", "width": 130 },
                     { "type": "natural" }
                 ],
-                "columnDefs": [ {
-                    "targets": 0,
-                    "orderable": false
-                } ],
                 "order": [[1, "asc" ]],
                 buttons: [
                     {

--- a/wqflask/wqflask/templates/correlation_page.html
+++ b/wqflask/wqflask/templates/correlation_page.html
@@ -175,9 +175,13 @@
                         <TD data-export="N/A">N/A</TD>
                         {% endif %}
                         <td data-export="{{ trait.pubmed_text }}">
+                            {% if trait.pubmed_text != "N/A" %}
                             <a href="{{ trait.pubmed_link }}">
                                 {{ trait.pubmed_text }}
                             </a>
+                            {% else %}
+                            {{ trait.pubmed_text }}
+                            {% endif %}
                         </td>
                         <td data-export="{{ '%0.3f'|format(trait.sample_r) }}" align="right"><a target="_blank" href="corr_scatter_plot?dataset_1={{dataset.name}}&dataset_2={{trait.dataset.name}}&trait_1={{this_trait.name}}&trait_2={{trait.name}}">{{ '%0.3f'|format(trait.sample_r) }}</a></td>
                         <td data-export="{{ trait.num_overlap }}" align="right">{{ trait.num_overlap }}</td>

--- a/wqflask/wqflask/templates/correlation_page.html
+++ b/wqflask/wqflask/templates/correlation_page.html
@@ -369,9 +369,9 @@
                     { "type": "numeric-html", 'orderSequence': [ "desc", "asc"] },
                     { "type": "numeric-html", 'orderSequence': [ "desc", "asc"] },
                     { "type": "scientific" },
-                    { "type": "natural" },
-                    { "type": "natural" },
-                    { "type": "natural" }
+                    { "type": "natural-minus-na" },
+                    { "type": "natural-minus-na" },
+                    { "type": "natural-minus-na" }
                 ],
                 "createdRow": function ( row, data, index ) {
                     $('td', row).eq(4).attr('title', $('td', row).eq(4).text());
@@ -423,13 +423,13 @@
                     { "type": "natural" },
                     { "type": "natural", "width": "20%" },
                     { "type": "natural", "width": "12%" },
-                    { "orderDataType": "dom-innertext" },
+                    { "type": "natural-minus-na" },
                     { "orderDataType": "dom-innertext", 'orderSequence': [ "desc", "asc"] },
                     { "type": "natural" },
                     { "type": "scientific" },
-                    { "type": "natural" },
-                    { "type": "natural" },
-                    { "type": "natural" }
+                    { "type": "natural-minus-na" },
+                    { "type": "natural-minus-na" },
+                    { "type": "natural-minus-na" }
                 ],
                 "order": [[9, "asc" ]],
                 "sDom": "Btir",
@@ -465,7 +465,7 @@
                     { "type": "natural" },
                     { "type": "natural" },
                     { "orderDataType": "dom-innertext", 'orderSequence': [ "desc", "asc"] },
-                    { "type": "natural" },
+                    { "type": "natural-minus-na" },
                     { "type": "scientific" }
                 ],
                 "order": [[6, "asc" ]],

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -274,10 +274,9 @@
                     },
                     {
                       'title': "Record",
-                      'type': "natural",
+                      'type': "natural-minus-na",
                       'data': null,
                       'width': "60px",
-                      'orderDataType': "dom-inner-text",
                       'render': function(data, type, row, meta) {
                         return '<a target="_blank" href="/show_trait?trait_id=' + data.name + '&dataset=' + data.dataset + '">' + data.display_name + '</a>'
                       }
@@ -367,17 +366,11 @@
                           author_string = data.authors
                         }
                         return author_string
-                        // try {
-                        //   return decodeURIComponent(escape(author_string))
-                        // } catch(err){
-                        //   return author_string
-                        // }
                       }
                     },
                     {
                       'title': "Year",
                       'type': "natural-minus-na",
-                      'orderDataType': "dom-inner-text",
                       'data': null,
                       'width': "80px",
                       'render': function(data, type, row, meta) {


### PR DESCRIPTION
#### Description
Columns containing hyperlinks weren't sorting correctly in some tables. This happened because the hyperlinks were sorted by using a "dom-inner-text" orderDataType in the DataTables column definitions, but because orderDataType can only reference the DOM it would only sort the first page of results (and would throw an error if attempting to simultaneously also use a custom data type for the column). This PR adds a JS method that extracts the inner text from an HTML string and incorporates that method into the "natural-minus-na" sort method (since it will always be the case that we both want to sort by inner-text when HTML is inside of a table cell and show N/As at the bottom).

#### How should this be tested?
- Do a phenotype search containing more than 500 results (so there will be multiple pages of results) and sort by the Record or Year columns
- Add more than 500 traits to a collection and sort by the Record column

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
