### PR TITLE
Corr matrix error fix

### DIFF
--- a/wqflask/base/data_set.py
+++ b/wqflask/base/data_set.py
@@ -1173,40 +1173,6 @@ class TempDataSet(DataSet):
         self.fullname = 'Temporary Storage'
         self.shortname = 'Temp'
 
-    @staticmethod
-    def handle_pca(desc):
-        if 'PCA' in desc:
-            # Todo: Modernize below lines
-            desc = desc[desc.rindex(':')+1:].strip()
-        else:
-            desc = desc[:desc.index('entered')].strip()
-        return desc
-
-    def get_desc(self):
-        query = 'SELECT description FROM Temp WHERE Name=%s' % self.name
-        logger.sql(query)
-        g.db.execute(query)
-        desc = g.db.fetchone()[0]
-        desc = self.handle_pca(desc)
-        return desc
-
-    def retrieve_sample_data(self, trait):
-        query = """
-                SELECT
-                        Strain.Name, TempData.value, TempData.SE, TempData.NStrain, TempData.Id
-                FROM
-                        TempData, Temp, Strain
-                WHERE
-                        TempData.StrainId = Strain.Id AND
-                        TempData.Id = Temp.DataId AND
-                        Temp.name = '%s'
-                Order BY
-                        Strain.Name
-                """ % escape(trait.name)
-
-        logger.sql(query)
-        results = g.db.execute(query).fetchall()
-
 
 def geno_mrna_confidentiality(ob):
     dataset_table = ob.type + "Freeze"

--- a/wqflask/wqflask/correlation_matrix/show_corr_matrix.py
+++ b/wqflask/wqflask/correlation_matrix/show_corr_matrix.py
@@ -147,7 +147,7 @@ class CorrelationMatrix(object):
 
                     if num_overlap < self.lowest_overlap:
                         self.lowest_overlap = num_overlap
-                    if num_overlap == 0:
+                    if num_overlap < 2:
                         corr_result_row.append([target_trait, 0, num_overlap])
                         pca_corr_result_row.append(0)
                     else:


### PR DESCRIPTION
#### Description
Running Correlation Matrix caused an error if traits with exactly 1 sample in common were included. 

PCA traits still aren't calculated, but this fix removed the error and at allows the matrix to be generated. I'll fix the PCA traits later, but wanted to get this fix up quickly since it's a more urgent issue.

(I also removed some unused code in dataset.py that I encountered while troubleshooting the problem)

#### How should this be tested?
Run Correlation Matrix on BXD phenotype traits 11515, 12840, 10049, 10417, and 15099

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)

#### Questions
