### PR TITLE
Checked if owner_id is "none" to avoid an error when trying to access…

### DIFF
--- a/wqflask/wqflask/resource_manager.py
+++ b/wqflask/wqflask/resource_manager.py
@@ -25,16 +25,16 @@ def manage_resource():
         group_masks_with_names = get_group_names(group_masks)
         default_mask = resource_info['default_mask']['data']
         owner_id = resource_info['owner_id']
-        owner_info = get_user_by_unique_column("user_id", owner_id)
 
-        if 'name' in owner_info:
-            owner_display_name = owner_info['full_name']
-        elif 'user_name' in owner_info:
-            owner_display_name = owner_info['user_name']
-        elif 'email_address' in owner_info:
-            owner_display_name = owner_info['email_address']
-        else:
-            owner_display_name = None
+        owner_display_name = None
+        if owner_id != "none":
+            owner_info = get_user_by_unique_column("user_id", owner_id)
+            if 'name' in owner_info:
+                owner_display_name = owner_info['full_name']
+            elif 'user_name' in owner_info:
+                owner_display_name = owner_info['user_name']
+            elif 'email_address' in owner_info:
+                owner_display_name = owner_info['email_address']
 
         return render_template("admin/manage_resource.html", owner_name = owner_display_name, resource_id = resource_id, resource_info=resource_info, default_mask=default_mask, group_masks=group_masks_with_names, admin_status=admin_status)
 


### PR DESCRIPTION
#### Description
When trying to access the resource manager page for a newly added dataset it would throw an error caused by owner_id being "none" (the default value for an owner_id). This occurred as a KeyError when trying to fetch the owner's user info. As a result I made fetching the owner info contingent on the owner_id not being "none".

#### How should this be tested?
When a new dataset is added, try going to the resource page for that data (this might require being a superuser though, since other people shouldn't be able to access the resource page)

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
