### PR TITLE
Index page dropdown/textarea fix

### DIFF
--- a/wqflask/wqflask/templates/index_page_orig.html
+++ b/wqflask/wqflask/templates/index_page_orig.html
@@ -17,13 +17,13 @@
     </header>
 -->
 
-    <div class="container-fluid" style="min-width: 1200px;">
+    <div class="container-fluid" style="min-width: 1210px;">
 
         {{ flash_me() }}
 
         <div class="row" style="width: 100%;">
 
-            <div class="col-xs-5" style="min-width: 530px; max-width: 550px;">
+            <div class="col-xs-4" style="margin-right:50px; min-width: 530px; max-width: 550px;">
                 <section id="search">
                     <div>
                         <h1>Select and search</h1>
@@ -84,7 +84,7 @@
                                     <label for="or_search" class="col-xs-1 control-label" style="padding-left: 0px; padding-right: 0px; width: 65px !important;">Get Any:</label>
                                     <div class="col-xs-10 controls" style="padding-left: 20px;">
                                         <div class="col-8">
-                                          <textarea onkeydown="pressed(event)" name="search_terms_or" rows="1" class="form-control search-query" style="max-width: 550px; width: 450px !important;" id="or_search"></textarea>
+                                          <textarea onkeydown="pressed(event)" name="search_terms_or" rows="1" class="form-control search-query" style="resize: vertical; max-width: 550px; width: 450px !important;" id="or_search"></textarea>
                                         </div>
                                     </div>
                                 </div>
@@ -105,7 +105,7 @@
                                     <label for="and_search" class="col-xs-1 control-label" style="padding-left: 0px; padding-right: 0px; width: 65px !important;">Combined:</label>
                                     <div class="col-xs-10 controls" style="padding-left: 20px;">
                                         <div class="col-8">
-                                          <textarea onkeydown="pressed(event)" name="search_terms_and" rows="1" class="form-control search-query" style="max-width: 550px; width: 450px !important;" id="and_search"></textarea>
+                                          <textarea onkeydown="pressed(event)" name="search_terms_and" rows="1" class="form-control search-query" style="resize: vertical; max-width: 550px; width: 450px !important;" id="and_search"></textarea>
                                         </div>
                                     </div>
                                 </div>
@@ -184,7 +184,7 @@
                 </section>
             </div>
 
-            <div style="padding-left:80px" class="col-xs-4" style="width: 600px !important;">
+            <div class="col-xs-4" style="width: 600px !important;">
 	        <section id="affiliates">
 	            <div class="page-header">
                         <h1>Affiliates</h1>


### PR DESCRIPTION
#### Description
Drop-down arrows and the bottom right corners of textareas couldn't be clicked on the index page with screens below a certain width, due to the left and right sides of the page overlapping at those widths.
A change was made to prevent them from overlapping and to make textareas only expandable vertically to prevent them from being able to overlap with the right side of the page

#### How should this be tested?
Open the index page and try to open all the drop-down menus and expand the search textareas

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
