### PR TITLE
Made change that should fix error when trying to change page text usi…

### DIFF
--- a/wqflask/wqflask/docs.py
+++ b/wqflask/wqflask/docs.py
@@ -11,7 +11,7 @@ class Docs(object):
 
     def __init__(self, entry, start_vars={}):
         sql = """
-            SELECT Docs.title, Docs.content
+            SELECT Docs.title, CAST(Docs.content AS BINARY)
             FROM Docs
             WHERE Docs.entry LIKE %s
             """
@@ -22,7 +22,7 @@ class Docs(object):
             self.content = ""
         else:
             self.title = result[0]
-            self.content = result[1].encode("latin1")
+            self.content = result[1]
 
         self.editable = "false"
         # ZS: Removing option to edit to see if text still gets vandalized

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -50,7 +50,7 @@ from wqflask.search_results import SearchResultPage
 from wqflask.export_traits import export_search_results_csv
 from wqflask.gsearch import GSearch
 from wqflask.update_search_results import GSearch as UpdateGSearch
-from wqflask.docs import Docs
+from wqflask.docs import Docs, update_text
 from wqflask.db_info import InfoPage
 
 from utility import temp_data
@@ -350,7 +350,7 @@ def environments():
 
 @app.route("/update_text", methods=('POST',))
 def update_page():
-    docs.update_text(request.form)
+    update_text(request.form)
     doc = Docs(request.form['entry_type'], request.form)
     return render_template("docs.html", **doc.__dict__)
 


### PR DESCRIPTION
#### Description
There was an error when attempting to update text for pages like References, Links, etc using ckeditor. The direct cause of the error was update_text not being imported in views.py from Docs.py, but after importing it there was another error when decoding DB contents as latin1 (in Docs.py). I instead cast the SQL results as binary (which I think is how we deal with this in the proxy) and it seems to have fixed the problem.

#### How should this be tested?
Try to edit text for the References page using ckeditor (currently I think only Rob and me can do this, though)

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/a

#### Screenshots (if appropriate)

#### Questions
