### PR TITLE
Some trait page width changes

### DIFF
--- a/wqflask/wqflask/templates/show_trait.html
+++ b/wqflask/wqflask/templates/show_trait.html
@@ -37,7 +37,7 @@
         <input type="hidden" name="covariates" value="">
         <input type="hidden" name="transform" value="">
 
-        <div class="container" style="min-width: 1450px;">
+        <div class="container" style="min-width: 700px;">
             <div class="panel-group" id="accordion">
                 <div class="panel panel-default">
                     <div class="panel-heading" data-toggle="collapse" data-parent="#accordion" data-target="#collapseOne" aria-expanded="true">

--- a/wqflask/wqflask/templates/show_trait_calculate_correlations.html
+++ b/wqflask/wqflask/templates/show_trait_calculate_correlations.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="col-xs-7">
+  <div class="col-xs-6" style="min-width: 800px;">
     <div style="padding: 20px" class="form-horizontal">
         
         <div class="form-group">
@@ -39,7 +39,7 @@
         
         <div class="form-group">
             <label for="corr_return_results" class="col-xs-2 control-label">Return</label>
-            <div class="col-xs-3 controls">
+            <div class="col-xs-4 controls">
                 <select name="corr_return_results" class="form-control">
                     {% for return_result in corr_tools.return_results_menu %}
                         <option value="{{ return_result }}" 
@@ -55,7 +55,7 @@
         
         <div class="form-group">
             <label for="corr_samples_group" class="col-xs-2 control-label">Samples</label>
-            <div class="col-xs-3 controls">
+            <div class="col-xs-4 controls">
                 <select name="corr_samples_group" class="form-control">
                     {% for group, pretty_group in sample_group_types.items() %}
                         <option value="{{ group }}">{{ pretty_group }}</option>
@@ -66,7 +66,7 @@
             
         <div id="corr_sample_method" class="form-group">
             <label for="corr_sample_method" class="col-xs-2 control-label">Type</label>
-            <div class="col-xs-3 controls">
+            <div class="col-xs-4 controls">
                 <select name="corr_sample_method" class="form-control">
                     <option value="pearson">Pearson</option>
                     <option value="spearman">Spearman Rank</option>
@@ -77,7 +77,7 @@
         {% if dataset.type != "Publish" %}
         <div class="form-group">
             <label class="col-xs-2 control-label">Min Expr</label>
-            <div class="col-xs-3 controls">
+            <div class="col-xs-4 controls">
                 <input name="min_expr" value="" type="text" class="form-control" style="width: 70px;">
             </div>
         </div>
@@ -114,7 +114,7 @@
         </div>
     </div>
   </div>
-  <div class="col-xs-5">
+  <div>
     <span id="sample_r_desc" class="correlation_desc fs12">
         The <a href="http://genenetwork.org/correlationAnnotation.html#genetic_r">Sample Correlation</a>
         is computed

--- a/wqflask/wqflask/templates/show_trait_mapping_tools.html
+++ b/wqflask/wqflask/templates/show_trait_mapping_tools.html
@@ -397,8 +397,8 @@
             </div>
         </div>
     </div>
-    <div class="col-xs-7">
-        <dl style="width: 500px;">
+    <div>
+        <dl>
              {% for mapping_method in dataset.group.mapping_names %}
              {% if mapping_method == "GEMMA" %}
              <dt style="padding-top: 20px;">GEMMA</dt>


### PR DESCRIPTION
#### Description
Rob mentioned the trait page description text growing too wide with certain screen sizes, so I allowed it to shrink with screen size and also applied this to correlation and mapping method descriptions

#### How should this be tested?
Open the trait page for a trait like the one below and look at the Summary and at the right sides of the Mapping and Correlation sections (when expanded)
https://genenetwork.org/show_trait?trait_id=ILMN_1090075&dataset=GSE15222_F_RI_0409

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
