### PR TITLE
Fixed issue where new phenotype groups wouldn't be saved to the self.…

### DIFF
--- a/wqflask/base/data_set.py
+++ b/wqflask/base/data_set.py
@@ -150,10 +150,11 @@ Publish or ProbeSet. E.g.
             "geno": "Geno",
         }
 
+        group_name = name
         if t in ['pheno', 'other_pheno']:
-            name = name.replace("Publish", "")
+            group_name = name.replace("Publish", "")
 
-        if bool(len(g.db.execute(sql_query_mapping[t].format(name)).fetchone())):
+        if bool(len(g.db.execute(sql_query_mapping[t].format(group_name)).fetchone())):
             self.datasets[name] = dataset_name_mapping[t]
             self.redis_instance.set("dataset_structure", json.dumps(self.datasets))
             return True

--- a/wqflask/base/data_set.py
+++ b/wqflask/base/data_set.py
@@ -154,7 +154,8 @@ Publish or ProbeSet. E.g.
         if t in ['pheno', 'other_pheno']:
             group_name = name.replace("Publish", "")
 
-        if bool(len(g.db.execute(sql_query_mapping[t].format(group_name)).fetchone())):
+        results = g.db.execute(sql_query_mapping[t].format(group_name)).fetchone()
+        if results:
             self.datasets[name] = dataset_name_mapping[t]
             self.redis_instance.set("dataset_structure", json.dumps(self.datasets))
             return True


### PR DESCRIPTION
#### Description
After changing the group name BXD-Harvested to BXD-Longevity there was an error when searching. This was caused by new phenotype datasets being added to self.datasets (which stores links between dataset names and their types - Publish/ProbeSet/Geno) with the group name as a key ("BXD-Longevity" in this case) instead of the dataset name ("BXD-LongevityPublish"). Fixing this appears to have fixed the issue.

#### How should this be tested?
Try a search like this - https://genenetwork.org/search?species=mouse&group=BXD-Longevity&type=Phenotypes&dataset=BXD-LongevityPublish&search_terms_or=10005&search_terms_and=&FormID=searchResult

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
