### PR TITLE
Change some column widths/headers in search and view collection pages

### DIFF
--- a/wqflask/wqflask/templates/collections/view.html
+++ b/wqflask/wqflask/templates/collections/view.html
@@ -8,7 +8,7 @@
 {% block content %}
 <!-- Start of body -->
 
-    <div class="container" style="min-width: 2050px;">
+    <div class="container">
         <h1>
             <span id="collection_name">{{ uc.name }}</span>
             <input type="text" name="new_collection_name" style="font-size: 20px; display: none; width: 500px;" class="form-control" placeholder="{{ uc.name }}"> 
@@ -85,7 +85,7 @@
             <div style="margin-top: 10px; margin-bottom: 5px;">
                 <b>Show/Hide Columns:</b>
             </div>
-            <div>
+            <div style="min-width: 1500px;">
                 <table class="table-hover table-striped cell-border" id='trait_table' style="float: left;">
                     <thead>
                         <tr>
@@ -97,7 +97,7 @@
                             <th data-export="Description">Description</th>
                             <th data-export="Location">Location</th>
                             <th data-export="Mean">Mean</th>
-                            <th data-export="Max LRS">Max LRS <a href="http://genenetwork.org//glossary.html#L" target="_blank"><sup style="font-size: small; color: #FF0000;"> ?</sup></a></th>
+                            <th data-export="Max LRS">High P <a href="http://genenetwork.org//glossary.html#L" target="_blank"><sup style="font-size: small; color: #FF0000;"> ?</sup></a></th>
                             <th data-export="Peak Location">Peak Location</th>
                             <th data-export="Add. Eff.">Effect Size <a href="http://genenetwork.org//glossary.html#A" target="_blank"><sup style="font-size: small; color: #FF0000;"> ?</sup></a></th>
                         </tr>
@@ -195,11 +195,11 @@
                     { 'type': "natural-minus-na", "width": 120 },
                     { "type": "natural" },
                     { "type": "natural"  },
-                    { "type": "natural", "width": 130 },
-                    { "type": "natural", "width": 35 },
-                    { "type": "natural", "width": 35 },
-                    { "type": "natural", "width": 130 },
-                    { "type": "natural" }
+                    { "type": "natural", "width": 125 },
+                    { "type": "natural", "width": 60 },
+                    { "type": "natural", "width": 60 },
+                    { "type": "natural", "width": 125 },
+                    { "type": "natural", "width": 85 }
                 ],
                 "order": [[1, "asc" ]],
                 buttons: [

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -140,7 +140,6 @@
             <b>Show/Hide Columns:</b>
           </div>
           {% endif %}
-          <!--<div id="table_container" style="min-width: {% if dataset.type == 'ProbeSet' or dataset.type == 'Publish' %}2000{% else %}380{% endif %}px;">-->
           <div id="table_container" {% if dataset.type == 'ProbeSet' or dataset.type == 'Publish' %}style="min-width: 1500px;"{% endif %}>
             <table class="table-hover table-striped cell-border" id='trait_table' style="float: left; width: {% if dataset.type == 'Geno' %}380px{% else %}100%{% endif %};">
                 <tbody>
@@ -290,7 +289,6 @@
                     {
                       'title': "Description",
                       'type': "natural",
-                      'width': "500px",
                       'data': null,
                       'render': function(data, type, row, meta) {
                         try {
@@ -303,7 +301,7 @@
                     {
                       'title': "Location",
                       'type': "natural-minus-na",
-                      'width': "120px",
+                      'width': "125px",
                       'data': "location"
                     },
                     {
@@ -314,23 +312,23 @@
                       'orderSequence': [ "desc", "asc"]
                     },
                     {
-                      'title': "Max LRS<a href=\"http://genenetwork.org//glossary.html#LRS\" target=\"_blank\" style=\"color: white;\"><sup style=\"font-size: small; color: #FF0000;\"> ?</sup></a>",
+                      'title': "High P<a href=\"http://genenetwork.org//glossary.html#LRS\" target=\"_blank\" style=\"color: white;\"><sup style=\"font-size: small; color: #FF0000;\"> ?</sup></a>",
                       'type': "natural-minus-na",
                       'data': "lrs_score",
-                      'width': "80px",
+                      'width': "60px",
                       'orderSequence': [ "desc", "asc"]
                     },
                     {
                       'title': "Peak Location",
                       'type': "natural-minus-na",
-                      'width': "120px",
+                      'width': "125px",
                       'data': "lrs_location"
                     },
                     {
                       'title': "Effect Size<a href=\"http://genenetwork.org//glossary.html#A\" target=\"_blank\" style=\"color: white;\"><sup style=\"font-size: small; color: #FF0000;\"> ?</sup></a>",
                       'type': "natural-minus-na",
                       'data': "additive",
-                      'width': "120px",
+                      'width': "85px",
                       'orderSequence': [ "desc", "asc"]
                     }{% elif dataset.type == 'Publish' %},
                     {


### PR DESCRIPTION
#### Description
The "Max LRS" column was changed to "High P" to make it more narrow and the widths of the location columns and the overall table were changed to prevent locations from overflowing onto next line.

#### How should this be tested?
Do a search like the following and look at the table - https://genenetwork.org/search?species=mouse&group=BXD&type=Hippocampus+mRNA&dataset=NIAAA_BXD_Hip_CMS-DID_RNAseq1020&search_terms_or=mobility&search_terms_and=&FormID=searchResult

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
