### PR TITLE
Mapping y axis fix

### DIFF
--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -2074,9 +2074,7 @@ class DisplayMappingResults(object):
                         pass
 
             if self.permChecked and self.nperm > 0 and not self.multipleInterval:
-                if self.significant > LRS_LOD_Max:
-                    LRS_LOD_Max = self.significant * 1.1
-                #LRS_LOD_Max = max(self.significant, LRS_LOD_Max)
+                LRS_LOD_Max = max(self.significant, LRS_LOD_Max)
             else:
                 LRS_LOD_Max = 1.15*LRS_LOD_Max
 

--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -2075,8 +2075,6 @@ class DisplayMappingResults(object):
 
             if self.permChecked and self.nperm > 0 and not self.multipleInterval:
                 LRS_LOD_Max = max(self.significant, LRS_LOD_Max)
-            else:
-                LRS_LOD_Max = 1.15*LRS_LOD_Max
 
             #genotype trait will give infinite LRS
             LRS_LOD_Max = min(LRS_LOD_Max, webqtlConfig.MAXLRS)


### PR DESCRIPTION
#### Description
Currently it's possible for the top Y axis tick in the mapping figure to be above the figure itself, causing it to sometimes intersect with the legend. This fix aims to prevent that.

For now, I'm just removing the top tick when it's higher than the top of the figure. It would probably be preferable to scale everything so that the top of the figure corresponds to the top tick, but that's a bit more involved (since all the different tracks need to be adjusted accordingly).

#### How should this be tested?
Try mapping the following trait using R/qtl (either with or without permutations) - https://genenetwork.org/show_trait?trait_id=10015&dataset=HXBBXHPublish
Previously this figure had a tick mark above the top of the figure. With the fix, this tick mark shouldn't be displayed.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
