### PR TITLE
Fixed trait export for situations where there's no authors/title/journal

### DIFF
--- a/wqflask/wqflask/show_trait/export_trait_data.py
+++ b/wqflask/wqflask/show_trait/export_trait_data.py
@@ -37,9 +37,9 @@ def get_export_metadata(trait_id, dataset_name):
         metadata.append(["Phenotype URL: " + "http://genenetwork.org/show_trait?trait_id=" + trait_id + "&dataset=" + dataset_name])
         metadata.append(["Group: " + dataset.group.name])
         metadata.append(["Phenotype: " + this_trait.description_display.replace(",", "\",\"")])
-        metadata.append(["Authors: " + this_trait.authors])
-        metadata.append(["Title: " + this_trait.title])
-        metadata.append(["Journal: " + this_trait.journal])
+        metadata.append(["Authors: " + (this_trait.authors if this_trait.authors else "N/A")])
+        metadata.append(["Title: " + (this_trait.title if this_trait.title else "N/A")])
+        metadata.append(["Journal: " + (this_trait.journal if this_trait.journal else "N/A")])
         metadata.append(["Dataset Link: http://gn1.genenetwork.org/webqtl/main.py?FormID=sharinginfo&InfoPageName=" + dataset.name])
         metadata.append([])
 


### PR DESCRIPTION
#### Description
The export option on phenotype trait pages was failing when certain phenotype fields were missing (Authors, Title, or Journal). This fix just replaces those fields with "N/A" when they don't exist.

#### How should this be tested?
Do an Export for this trait (which doesn't have a Title in the DB) - https://genenetwork.org/show_trait?trait_id=18613&dataset=BXDPublish

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
