### PR TITLE
Add page load metrics to footer

### DIFF
--- a/wqflask/wqflask/__init__.py
+++ b/wqflask/wqflask/__init__.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
 import sys
+import time
 import jinja2
 
+from flask import g
 from flask import Flask
 from utility import formatting
 
@@ -18,6 +20,13 @@ app.config.from_envvar('GN2_SETTINGS')
 app.jinja_env.globals.update(
     undefined=jinja2.StrictUndefined,
     numify=formatting.numify)
+
+
+@app.before_request
+def before_request():
+   g.request_start_time = time.time()
+   g.request_time = lambda: "%.5fs" % (time.time() - g.request_start_time)
+
 
 from wqflask.api import router
 from wqflask import group_manager

--- a/wqflask/wqflask/templates/base.html
+++ b/wqflask/wqflask/templates/base.html
@@ -9,6 +9,9 @@
 
     <meta name="description" content="">
     <meta name="author" content="">
+    <script type="text/javascript">
+     var pageLoadStart = Date.now();
+    </script>
     <link rel="icon" type="image/png" sizes="64x64" href="/static/new/images/CITGLogo.png">
     <link rel="apple-touch-icon" type="image/png" sizes="64x64" href="/static/new/images/CITGLogo.png">
     <link REL="stylesheet" TYPE="text/css" href="/static/packages/bootstrap/css/bootstrap.css" />
@@ -203,6 +206,7 @@
             {% if version: %}
             <p><small>GeneNetwork {{ version }}</small></p>
             {% endif %}
+            <p> It took the server {{ g.request_time() }} seconds to process this page.</p>
 
         </div>
         <div class="col-xs-2">
@@ -256,6 +260,12 @@
     {% block js %}
     {% endblock %}
 
-
+    <script type="text/javascript">
+     $(window).load(function() {
+         let timeToLoad = document.createElement("p");
+         timeToLoad.innerHTML = "It took your browser " + ((Date.now() - pageLoadStart)/1000) + " second(s) to render this page";
+         document.querySelector("footer .row .col-xs-6").appendChild(timeToLoad);
+     });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
#### Description

This PR adds page load metrics to the footer for every page.

#### How should this be tested?

http://gn2-test1.genenetwork.org/ has been set-up **temporarily** so you can test things from there.
- Try out a fast-loading page: http://gn2-test1.genenetwork.org/
- Try out a slow-loading page: http://gn2-test1.genenetwork.org/gsearch?type=gene&terms=spp

Note that GH actions will fail. See: https://github.community/t/failing-tests-after-github-actions-degradation-resolution/139248

#### Any background context you want to provide?

Metrics displayed are both the request execution time from the server, and page rendering time from the client side. Had to have this separation because it's impossible(?) to know how fast some computation from the server took only from the client side, since we most of the rendering happens server side.

#### What are the relevant pivotal tracker stories?

N/A

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/11820306/97174439-2acb3280-17a3-11eb-9528-20851cbfd538.png)

#### Questions

N/A