### PR TITLE
Fix issue where attribute values were displayed in the wrong columns

### DIFF
--- a/wqflask/base/webqtlCaseData.py
+++ b/wqflask/base/webqtlCaseData.py
@@ -41,8 +41,6 @@ class webqtlCaseData:
         self.this_id = None   # Set a sane default (can't be just "id" cause that's a reserved word)
         self.outlier = None   # Not set to True/False until later
 
-        self.first_attr_col = self.get_first_attr_col()
-
     def __repr__(self):
         case_data_string = "<webqtlCaseData> "
         if self.value is not None:
@@ -81,12 +79,3 @@ class webqtlCaseData:
         if self.num_cases is not None:
             return "%s" % self.num_cases
         return "x"
-
-    def get_first_attr_col(self):
-        col_num = 4
-        if self.variance is not None:
-            col_num += 2
-        if self.num_cases is not None:
-            col_num += 1
-
-        return col_num

--- a/wqflask/wqflask/show_trait/SampleList.py
+++ b/wqflask/wqflask/show_trait/SampleList.py
@@ -8,7 +8,6 @@ from pprint import pformat as pf
 from utility import Plot
 from utility import Bunch
 
-
 class SampleList(object):
     def __init__(self,
                  dataset,
@@ -68,6 +67,12 @@ class SampleList(object):
             self.sample_list.append(sample)
 
         self.se_exists = any(sample.variance for sample in self.sample_list)
+        self.num_cases_exists = any(sample.num_cases for sample in self.sample_list)
+
+        first_attr_col = self.get_first_attr_col()
+        for sample in self.sample_list:
+            sample.first_attr_col = first_attr_col
+
         self.do_outliers()
 
     def __repr__(self):
@@ -147,6 +152,15 @@ class SampleList(object):
 
                     attribute_values[self.attributes[item.Id].name] = attribute_value
                 self.sample_attribute_values[sample_name] = attribute_values
+
+    def get_first_attr_col(self):
+        first_attr_col = 4
+        if self.se_exists:
+            first_attr_col += 2
+        if self.num_cases_exists:
+            first_attr_col += 1
+
+        return first_attr_col
 
 def natural_sort(list, key=lambda s: s):
     """

--- a/wqflask/wqflask/static/new/javascript/initialize_show_trait_tables.js
+++ b/wqflask/wqflask/static/new/javascript/initialize_show_trait_tables.js
@@ -75,7 +75,7 @@ build_columns = function() {
     );
   }
 
-  if (js_data.has_num_cases === "true") {
+  if (js_data.has_num_cases === true) {
     column_list.push(
       {
         'title': "<div style='text-align: right;'>N</div>",
@@ -101,7 +101,8 @@ build_columns = function() {
         'type': "natural",
         'data': null,
         'render': function(data, type, row, meta) {
-          attr_name = Object.keys(data.extra_attributes).sort((a, b) => (a > b) ? 1 : -1)[meta.col - data.first_attr_col]
+          attr_name = Object.keys(data.extra_attributes).sort()[meta.col - data.first_attr_col]
+
           if (attr_name != null && attr_name != undefined){
               return data.extra_attributes[attr_name]
           } else {
@@ -111,7 +112,6 @@ build_columns = function() {
       }
     )
   }
-
   return column_list
 }
 
@@ -132,23 +132,22 @@ var primary_table = $('#samples_primary').DataTable( {
       $('td', row).eq(3).addClass("column_name-Value")
       if (js_data.se_exists) {
         $('td', row).eq(5).addClass("column_name-SE")
-        if (js_data.has_num_cases === "true") {
+        if (js_data.has_num_cases === true) {
           $('td', row).eq(6).addClass("column_name-num_cases")
         } else {
-          if (js_data.has_num_cases === "true") {
+          if (js_data.has_num_cases === true) {
             $('td', row).eq(4).addClass("column_name-num_cases")
           }
         }
       } else {
-        if (js_data.has_num_cases === "true") {
+        if (js_data.has_num_cases === true) {
           $('td', row).eq(4).addClass("column_name-num_cases")
         }
       }
 
-      sorted_key_list = Object.keys(js_data.attributes).sort()
-      for (i=0; i < sorted_key_list.length; i++) {
-        $('td', row).eq(attribute_start_pos + i + 1).addClass("column_name-" + js_data.attributes[sorted_key_list[i]].name)
-        $('td', row).eq(attribute_start_pos + i + 1).attr("style", "text-align: " + js_data.attributes[sorted_key_list[i]].alignment + "; padding-top: 2px; padding-bottom: 0px;")
+      for (i=0; i < attr_keys.length; i++) {
+        $('td', row).eq(attribute_start_pos + i).addClass("column_name-" + js_data.attributes[attr_keys[i]].name)
+        $('td', row).eq(attribute_start_pos + i).attr("style", "text-align: " + js_data.attributes[attr_keys[i]].alignment + "; padding-top: 2px; padding-bottom: 0px;")
       }
     },
     'data': js_data['sample_lists'][0],
@@ -190,23 +189,22 @@ if (js_data.sample_lists.length > 1){
         $('td', row).eq(3).addClass("column_name-Value")
         if (js_data.se_exists) {
           $('td', row).eq(5).addClass("column_name-SE")
-          if (js_data.has_num_cases === "true") {
+          if (js_data.has_num_cases === true) {
             $('td', row).eq(6).addClass("column_name-num_cases")
           } else {
-            if (js_data.has_num_cases === "true") {
+            if (js_data.has_num_cases === true) {
               $('td', row).eq(4).addClass("column_name-num_cases")
             }
           }
         } else {
-          if (js_data.has_num_cases === "true") {
+          if (js_data.has_num_cases === true) {
             $('td', row).eq(4).addClass("column_name-num_cases")
           }
         }
 
-        sorted_key_list = Object.keys(js_data.attributes).sort()
-        for (i=0; i < sorted_key_list.length; i++) {
-          $('td', row).eq(attribute_start_pos + i + 1).addClass("column_name-" + js_data.attributes[sorted_key_list[i]].name)
-          $('td', row).eq(attribute_start_pos + i + 1).attr("style", "text-align: " + js_data.attributes[sorted_key_list[i]].alignment + "; padding-top: 2px; padding-bottom: 0px;")
+        for (i=0; i < attr_keys.length; i++) {
+          $('td', row).eq(attribute_start_pos + i + 1).addClass("column_name-" + js_data.attributes[attr_keys[i]].name)
+          $('td', row).eq(attribute_start_pos + i + 1).attr("style", "text-align: " + js_data.attributes[attr_keys[i]].alignment + "; padding-top: 2px; padding-bottom: 0px;")
         }
       },
       'data': js_data['sample_lists'][1],


### PR DESCRIPTION
#### Description
There was a problem with the trait page table for situations where only some samples had an N and case attributes exist (for ones with the N the case attributes would be shifted over a column).

While fixing this, I noticed another problem that was causing the N column to not be drawn.

#### How should this be tested?
Look at the case attribute columns for this trait - http://genenetwork.org/show_trait?trait_id=10033&dataset=BXD-LongevityPublish
Previously all the rows with values had the case attribute values shifted to the left, causing the left-most column to be empty. N cases also wasn't displayed, which it should be now.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
