### PR TITLE
Remaining gsearch encoding fix for ProbeSet description

### DIFF
--- a/wqflask/wqflask/gsearch.py
+++ b/wqflask/wqflask/gsearch.py
@@ -35,7 +35,7 @@ class GSearch(object):
                 ProbeSetFreeze.FullName AS probesetfreeze_fullname,
                 ProbeSet.Name AS probeset_name,
                 ProbeSet.Symbol AS probeset_symbol,
-                ProbeSet.`description` AS probeset_description,
+                CAST(ProbeSet.`description` AS BINARY) AS probeset_description,
                 ProbeSet.Chr AS chr,
                 ProbeSet.Mb AS mb,
                 ProbeSetXRef.Mean AS mean,


### PR DESCRIPTION
#### Description
There was one more field in the global search query that needed to be cast as binary in the query so encode wouldn't throw an error.

#### How should this be tested?
Do a global search of "shh" for Genes/Molecules

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
