### PR TITLE
Fixed trait page export issue caused by Scroller

### DIFF
--- a/wqflask/wqflask/show_trait/export_trait_data.py
+++ b/wqflask/wqflask/show_trait/export_trait_data.py
@@ -14,10 +14,16 @@ def export_sample_table(targs):
 
     final_sample_data = meta_data
 
+    column_headers = ["Name", "Value"]
+    if any(sample["se"] for sample in sample_data['primary_samples']):
+        column_headers.append("SE")
+    if any(sample["num_cases"] for sample in sample_data['primary_samples']):
+        column_headers.append("N")
+
+    final_sample_data.append(column_headers)
     for sample_group in ['primary_samples', 'other_samples']:
         for row in sample_data[sample_group]:
             sorted_row = dict_to_sorted_list(row)
-            print("sorted_row is:", pf(sorted_row))
             final_sample_data.append(sorted_row)
 
     return trait_name, final_sample_data
@@ -39,7 +45,15 @@ def get_export_metadata(trait_id, dataset_name):
         metadata.append(["Title: " + (this_trait.title if this_trait.title else "N/A")])
         metadata.append(["Journal: " + (this_trait.journal if this_trait.journal else "N/A")])
         metadata.append(["Dataset Link: http://gn1.genenetwork.org/webqtl/main.py?FormID=sharinginfo&InfoPageName=" + dataset.name])
-        metadata.append([])
+    else:
+        metadata.append(["Record ID: " + trait_id])
+        metadata.append(["Trait URL: " + "http://genenetwork.org/show_trait?trait_id=" + trait_id + "&dataset=" + dataset_name])
+        if this_trait.symbol:
+            metadata.append(["Symbol: " + this_trait.symbol])
+        metadata.append(["Dataset: " + dataset.name])
+        metadata.append(["Group: " + dataset.group.name])
+
+    metadata.append([])
 
     return metadata
 

--- a/wqflask/wqflask/static/new/javascript/show_trait.js
+++ b/wqflask/wqflask/static/new/javascript/show_trait.js
@@ -885,26 +885,65 @@ $('#qnorm').click(switch_qnorm_data);
 get_sample_table_data = function(table_name) {
   var samples;
   samples = [];
-  $('#' + table_name).find('.value_se').each((function(_this) {
-    return function(_index, element) {
-      var attribute_info, key, row_data, _ref;
-      row_data = {};
-      row_data.name = $.trim($(element).find('.column_name-Sample').text());
-      row_data.value = $(element).find('.edit-sample-value:eq(0)').val();
-      if ($(element).find('.edit-sample-se').length > 0) {
-        row_data.se = $(element).find('.edit-sample-se').val();
+
+  var se_exists = false;
+  var n_exists = false;
+
+  if ($('#' + table_name).length){
+    table_api = $('#' + table).DataTable();
+    sample_vals = [];
+
+    name_nodes = table_api.column(2).nodes().to$();
+    val_nodes = table_api.column(3).nodes().to$();
+    if (js_data.se_exists){
+      var_nodes = table_api.column(5).nodes().to$();
+      if (js_data.has_num_cases) {
+        n_nodes = table_api.column(6).nodes().to$();
       }
-      if ($(element).find('.edit_sample_num_cases').length > 0) {
-        row_data.num_cases = $(element).find('.edit_sample_num_cases').val();
+    } else {
+      if (js_data.has_num_cases){
+        n_nodes = table_api.column(4).nodes().to$();
       }
-      attr_keys = Object.keys(js_data.attributes).sort()
-      for (i=0; i < attr_keys.length; i++) {
-        attribute_info = js_data.attributes[attr_keys[i]];
-        row_data[attribute_info.name] = $.trim($(element).find('.column_name-' + attribute_info.name.replace(" ", "_").replace("/", "\\/")).text());
+    }
+
+    for (_j = 0; _j < val_nodes.length; _j++){
+      sample_val = val_nodes[_j].childNodes[0].value
+      sample_name = $.trim(name_nodes[_j].childNodes[0].textContent)
+      if (is_number(sample_val) && sample_val !== "") {
+        sample_val = parseFloat(sample_val);
+        if (typeof var_nodes == 'undefined'){
+          sample_var = null;
+        } else {
+          sample_var = var_nodes[_j].childNodes[0].value;
+          if (is_number(sample_var)) {
+            sample_var = parseFloat(sample_var);
+            se_exists = true;
+          } else {
+            sample_var = null;
+          }
+        }
+        if (typeof n_nodes == 'undefined'){
+          sample_n = null;
+        } else {
+          sample_n = n_nodes[_j].childNodes[0].value;
+          if (is_number(sample_n)) {
+            n_exists = true;
+            sample_n = parseInt(sample_n);
+          } else {
+            sample_n = null;
+          }
+        }
+        row_dict = {
+          name: sample_name,
+          value: sample_val,
+          se: sample_var,
+          num_cases: sample_n
+        }
+        samples.push(row_dict)
       }
-      return samples.push(row_data);
-    };
-  })(this));
+    }
+  }
+
   return samples;
 };
 export_sample_table_data = function() {


### PR DESCRIPTION
#### Description
After switching to using DataTables Scroller for the trait page table, I apparently forgot to convert the export function to use DataTables API, so it wasn't working correctly. It should now work correctly, and I also added metadata for non-Phenotype traits and column headers (which didn't previously exist).

I still need to fix exporting case attributes, but this fixes the more immediate problem.

#### How should this be tested?
Open one of the following pages and click "Export" under "Review and Edit Data". The contents should now be correct, when previously there was only a column for the N (if it existed).
https://genenetwork.org/show_trait?trait_id=18570&dataset=BXDPublish
https://genenetwork.org/show_trait?trait_id=ENSMUSG00000002633&dataset=NIAAA_BXD_Hip_CMS-DID_RNAseq1020

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
