### PR TITLE
Fixed error when zooming into a chromosome when mapping

### DIFF
--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -2809,7 +2809,7 @@ class DisplayMappingResults(object):
                              f"end={theGO['TxEnd']}&"
                              f"geneName={theGO['GeneSymbol']}&"
                              f"s1={self.diffCol[0]}&s2=%d"),
-                            theGO["snpCount"] # The text to display
+                            str(theGO["snpCount"]) # The text to display
                         )
                         snpString.set_blank_target()
                         snpString.set_attribute("class", "normalsize")


### PR DESCRIPTION
#### Description
There was an error when zooming into a chromosome for mapping caused by an int being passed into HT.Link. I cast it as a string and that seems to fix the issue.

#### How should this be tested?
Map any trait and try to zoom into a chromosome

#### Any background context you want to provide?
This was likely part of the switchover to Python3

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
