### PR TITLE
Bug/Replace map on strip with a list comprehension that calls strip()

### DIFF
--- a/scripts/maintenance/readProbeSetSE_v7.py
+++ b/scripts/maintenance/readProbeSetSE_v7.py
@@ -72,14 +72,14 @@ GeneList = []
 isCont = 1
 header = fp.readline()
 header = header.strip().split('\t')
-header = list(map(string.strip, header))
+header = [item.strip() for item in header]
 nfield = len(header)
 line = fp.readline()
 
 kj = 0
 while line:
     line2 = line.strip().split('\t')
-    line2 = list(map(string.strip, line2))
+    line2 = [item.strip() for item in line2]
     if len(line2) != nfield:
         isCont = 0
         print(("Error : " + line))
@@ -110,7 +110,7 @@ isCont = 1
 fp.seek(0)
 header = fp.readline()
 header = header.strip().split('\t')
-header = list(map(string.strip, header))
+header = [item.strip() for item in header]
 header = list(map(translateAlias, header))
 header = header[dataStart:]
 Ids = []

--- a/wqflask/wqflask/marker_regression/plink_mapping.py
+++ b/wqflask/wqflask/marker_regression/plink_mapping.py
@@ -84,7 +84,7 @@ def get_samples_from_ped_file(dataset):
 
     while line:
         lineList = line.strip().split('\t')
-        lineList = list(map(string.strip, lineList))
+        lineList = [item.strip() for item in lineList]
 
         sample_name = lineList[0]
         sample_list.append(sample_name)
@@ -157,6 +157,6 @@ def parse_plink_output(output_filename, species):
 def build_line_list(line=None):
     line_list = line.strip().split(' ')# irregular number of whitespaces between columns
     line_list = [item for item in line_list if item !='']
-    line_list = list(map(string.strip, line_list))
+    line_list = [item.strip() for item in line_list]
 
     return line_list

--- a/wqflask/wqflask/snp_browser/snp_browser.py
+++ b/wqflask/wqflask/snp_browser/snp_browser.py
@@ -457,7 +457,7 @@ class SnpBrowser(object):
                 function_list = []
                 if function_details:
                     function_list = function_details.strip().split(",")
-                    function_list = list(map(string.strip, function_list))
+                    function_list = [item.strip() for item in function_list]
                     function_list[0] = function_list[0].title()
                     function_details = ", ".join(item for item in function_list)
                     function_details = function_details.replace("_", " ")
@@ -723,11 +723,11 @@ def get_effect_details_by_category(effect_name = None, effect_value = None):
     codon_effect_group_list = ['Start Lost', 'Stop Gained', 'Stop Lost', 'Nonsynonymous', 'Synonymous']
 
     effect_detail_list = effect_value.strip().split('|')
-    effect_detail_list = list(map(string.strip, effect_detail_list))
+    effect_detail_list = [item.strip() for item in effect_detail_list]
 
     for index, item in enumerate(effect_detail_list):
         item_list = item.strip().split(',')
-        item_list = list(map(string.strip, item_list))
+        item_list = [item.strip() for item in item_list]
 
         gene_id = item_list[0]
         gene_name = item_list[1]


### PR DESCRIPTION
#### Description

This PR replaces maps that call string.strip() with a list comprehension that calls strip on each element.

It fixes this error:
<img width="1121" alt="Screen Shot 2020-10-28 at 12 02 10 PM" src="https://user-images.githubusercontent.com/11820306/97503464-214df000-1986-11eb-85e4-dcfa202694e5.png">

#### How should this be tested?

- Reload the page from that :point_up:

#### Any background context you want to provide?

You can't do `list(map(string.strip, header))` in Python3.

#### What are the relevant pivotal tracker stories?

N/A

#### Screenshots (if appropriate)

N/A

#### Questions

N/A