### PR TITLE
Reaper bootstrap fix

### DIFF
--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -342,7 +342,7 @@ class DisplayMappingResults(object):
         if 'reaper_version' in list(start_vars.keys()) and self.mapping_method == "reaper":
             self.reaper_version = start_vars['reaper_version']
             if 'output_files' in start_vars:
-                self.output_files = ",".join(start_vars['output_files'])
+                self.output_files = ",".join([(the_file if the_file is not None else "") for the_file in start_vars['output_files']])
 
         self.categorical_vars = ""
         self.perm_strata = ""
@@ -752,7 +752,7 @@ class DisplayMappingResults(object):
                 BootChrCoord.append([Xc, self.bootResult[i]])
         else:
             for i, result in enumerate(self.qtlresults):
-                if result['chr'] == self.ChrList[self.selectedChr][0]:
+                if str(result['chr']) == str(self.ChrList[self.selectedChr][0]):
                     if self.plotScale == 'physic':
                         Xc = startX + (result['Mb']-self.startMb)*plotXScale
                     else:


### PR DESCRIPTION
#### Description
The positioning of the bootstrap results was wrong due to them not accounting for the pseudo-markers added when interval mapping. This was fixed, as well as a separate issue where setting bootstrap or permutations to 0 caused an error (there's a part of the code that converts the list of output files - gwa results, permutation results, and bootstrap results - into a string by joining it, and if one of those files was None it threw an error).

#### How should this be tested?
Do any mapping using qtlreaper and bootstrapping and check that the yellow bootstrap bars align with the QTLs. For the second error, set bootstrap or permutations to 0 and do qtlreaper mapping.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
