### PR TITLE
Mapping Y Axis Fix

### DIFF
--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -2146,9 +2146,6 @@ class DisplayMappingResults(object):
             LRSScale = 1.0
 
         LRSAxisList = Plot.frange(LRSScale, LRS_LOD_Max, LRSScale)
-        #make sure the user's value appears on the y-axis
-        #update by NL 6-21-2011: round the LOD value to 100 when LRS_LOD_Max is equal to 460
-        LRSAxisList.append(ceil(LRS_LOD_Max))
 
         #ZS: Convert to int if all axis values are whole numbers
         all_int = True


### PR DESCRIPTION
#### Description
There was one remaining way that a tick could be drawn above the mapping figure; it would append the ceiling of the max LRS/LOD value to the axis value list, so I removed that line.

#### How should this be tested?
Do QTLReaper mapping with the following trait and 0 permutations: https://genenetwork.org/show_trait?trait_id=18570&dataset=BXDPublish

#### Any background context you want to provide?
This is a follow-up to a previous fix intended to solve the same problem.

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions
