### PR TITLE
Correlation errors fix

### DIFF
--- a/wqflask/utility/redis_tools.py
+++ b/wqflask/utility/redis_tools.py
@@ -25,6 +25,10 @@ def is_redis_available():
     return True
 
 
+def load_json_from_redis(item_list, column_value):
+    return json.loads(item_list[str.encode(column_value)])
+
+
 def get_user_id(column_name, column_value):
     user_list = Redis.hgetall("users")
     key_list = []
@@ -46,7 +50,7 @@ def get_user_by_unique_column(column_name, column_value):
             if column_name in user_ob and user_ob[column_name] == column_value:
                 item_details = user_ob
     else:
-        item_details = json.loads(user_list[column_value])
+        item_details = load_json_from_redis(user_list, column_value)
 
     return item_details
 
@@ -70,7 +74,7 @@ def get_users_like_unique_column(column_name, column_value):
                     if column_value in user_ob[column_name]:
                         matched_users.append(user_ob)
         else:
-            matched_users.append(json.loads(user_list[column_value]))
+            matched_users.append(load_json_from_redis(user_list, column_value))
 
     return matched_users
 
@@ -199,7 +203,7 @@ def get_groups_like_unique_column(column_name, column_value):
                         if column_value in group_info[column_name]:
                             matched_groups.append(group_info)
         else:
-            matched_groups.append(json.loads(group_list[column_value]))
+            matched_groups.append(load_json_from_redis(group_list, column_value))
 
     return matched_groups
 

--- a/wqflask/wqflask/correlation/show_corr_results.py
+++ b/wqflask/wqflask/correlation/show_corr_results.py
@@ -184,6 +184,8 @@ class CorrelationResults(object):
 
             for _trait_counter, trait in enumerate(list(self.correlation_data.keys())[:self.return_number]):
                 trait_object = create_trait(dataset=self.target_dataset, name=trait, get_qtl_info=True, get_sample_info=False)
+                if not trait_object:
+                    continue
 
                 if self.target_dataset.type == "ProbeSet" or self.target_dataset.type == "Geno":
                     #ZS: Convert trait chromosome to an int for the location range option
@@ -434,15 +436,15 @@ class CorrelationResults(object):
 
         self.this_trait_vals, target_vals, num_overlap = corr_result_helpers.normalize_values(self.this_trait_vals, target_vals)
 
-        #ZS: 2015 could add biweight correlation, see http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3465711/
-        if self.corr_method == 'bicor':
-            sample_r, sample_p = do_bicor(self.this_trait_vals, target_vals)
-        elif self.corr_method == 'pearson':
-            sample_r, sample_p = scipy.stats.pearsonr(self.this_trait_vals, target_vals)
-        else:
-            sample_r, sample_p = scipy.stats.spearmanr(self.this_trait_vals, target_vals)
-
         if num_overlap > 5:
+            #ZS: 2015 could add biweight correlation, see http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3465711/
+            if self.corr_method == 'bicor':
+                sample_r, sample_p = do_bicor(self.this_trait_vals, target_vals)
+            elif self.corr_method == 'pearson':
+                sample_r, sample_p = scipy.stats.pearsonr(self.this_trait_vals, target_vals)
+            else:
+                sample_r, sample_p = scipy.stats.spearmanr(self.this_trait_vals, target_vals)
+
             if numpy.isnan(sample_r):
                 pass
             else:
@@ -635,3 +637,4 @@ def get_header_fields(data_type, corr_method):
                                 'Sample p(r)']
 
     return header_fields
+


### PR DESCRIPTION
#### Description
There were two errors occurring in the correlation page:
- Traits sharing fewer than 2 samples threw an error when attempting to calculate correlation
- Traits the user didn't have permission to view would throw an error

The first was fixed by moving an if statement checking if traits share more than 5 samples above the correlation calculation (it originally was after it for some reason), and the second was fixed by checking if trait_object is None during each loop (and skipping if it is).
#### How should this be tested?
Do a correlation of the following trait against BXD Phenotypes. It previously caused an error, but shouldn't after this fix.

#### Any background context you want to provide?
We should probably keep an eye open for other places where the encoding might be necessary, though I think I got all the ones in redis_tools.py

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions
