### PR TITLE
Joined sample names in primary_samples and all_samples with commas be…

### DIFF
--- a/wqflask/wqflask/show_trait/show_trait.py
+++ b/wqflask/wqflask/show_trait/show_trait.py
@@ -228,8 +228,8 @@ class ShowTrait(object):
         hddn = OrderedDict()
 
         if self.dataset.group.allsamples:
-            hddn['allsamples'] = ''.join(self.dataset.group.allsamples)
-        hddn['primary_samples'] = ''.join(self.primary_sample_names)
+            hddn['allsamples'] = ','.join(self.dataset.group.allsamples)
+        hddn['primary_samples'] = ','.join(self.primary_sample_names)
         hddn['trait_id'] = self.trait_id
         hddn['trait_display_name'] = self.this_trait.display_name
         hddn['dataset'] = self.dataset.name


### PR DESCRIPTION
#### Description
The N of samples wasn't being displayed correctly on the mapping loading screen (it was always displayed as 1). This was apparently because the primary_samples hidden input in the show_trait page had the list of samples without being joined by a comma (or any other character), and it was split by a comma when trying to get the N (so it just got an N of 1 due to there being no commas and it being a list of length 1). I'm not sure why this was working beforehand, but either way it should be fixed now.

#### How should this be tested?
Do any mapping with the following trait and check that the N on the loading page is 37 (instead of 1): http://gn2-zach.genenetwork.org/show_trait?trait_id=19215&dataset=BXDPublish

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
