### PR TITLE
Bug/haplotype analyst error fix

### DIFF
--- a/wqflask/base/GeneralObject.py
+++ b/wqflask/base/GeneralObject.py
@@ -28,7 +28,7 @@ class GeneralObject:
     """
     Base class to define an Object.
     a = [Spam(1, 4), Spam(9, 3), Spam(4,6)]
-    a.sort(lambda x, y: cmp(x.eggs, y.eggs))
+    a.sort(key = lambda x: x.eggs)
     """
 
     def __init__(self, *args, **kw):

--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -1460,7 +1460,7 @@ class DisplayMappingResults(object):
             else:
                 continue
 
-        smd.sort(lambda A, B: cmp(A.value, B.value))
+        smd.sort(key = lambda A: A.value)
         smd.reverse()
 
         samplelist = list(self.genotype.prgy)


### PR DESCRIPTION
#### Description
There was an error when trying to use the haplotype analyst that was caused by the syntax used with "sort" not being correct for Python 3. The syntax was changed to be correct.

I also fixed the syntax in the docstring of GeneralObject in the same way.

#### How should this be tested?
Do any mapping with the following trait, check "Haplotype Analyst" in the top menu options, and then zoom into a chromosome: https://genenetwork.org/show_trait?trait_id=1436869_at&dataset=HC_M2_0606_P

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
