### PR TITLE
Feature/filter samples by value

### DIFF
--- a/wqflask/wqflask/static/new/css/show_trait.css
+++ b/wqflask/wqflask/static/new/css/show_trait.css
@@ -145,11 +145,11 @@ input.corr-location {
   display: inline;
 }
 
-div.block-by-index-div {
+div.block-div {
   margin-bottom: 10px;
 }
 
-div.block-by-attribute-div {
+div.block-div-2 {
   margin-top:10px;
   margin-bottom:10px;
 }

--- a/wqflask/wqflask/static/new/javascript/show_trait.js
+++ b/wqflask/wqflask/static/new/javascript/show_trait.js
@@ -608,7 +608,7 @@ block_by_attribute_value = function() {
 };
 $('#exclude_group').click(block_by_attribute_value);
 block_by_index = function() {
-  var end_index, error, index, index_list, index_set, index_string, start_index, _i, _j, _k, _len, _len1, _ref, _results;
+  var end_index, error, index, index_list, index_set, index_string, start_index, _i, _j, _k, _len, _len1, _ref;
   index_string = $('#remove_samples_field').val();
   index_list = [];
   _ref = index_string.split(",");
@@ -630,7 +630,7 @@ block_by_index = function() {
       index_list.push(index);
     }
   }
-  _results = [];
+
   let block_group = $('#block_group').val();
   if (block_group === "other") {
     table_api = $('#samples_other').DataTable();
@@ -642,6 +642,45 @@ block_by_index = function() {
     index = index_list[_k];
     val_nodes[index - 1].childNodes[0].value = "x";
 
+  }
+};
+
+filter_by_value = function() {
+  let filter_logic = $('#filter_logic').val();
+  let filter_value = $('#filter_value').val();
+
+  block_group = $('#filter_group').val();
+  if (block_group === "other") {
+    table_api = $('#samples_other').DataTable();
+  } else {
+    table_api = $('#samples_primary').DataTable();
+  }
+
+  let val_nodes = table_api.column(3).nodes().to$();
+  for (i = 0; i < val_nodes.length; i++) {
+    let this_node = val_nodes[i].childNodes[0];
+    if(!isNaN(this_node.value) && !isNaN(filter_value)) {
+      if (filter_logic == "greater_than"){
+        if (parseFloat(this_node.value) <= parseFloat(filter_value)){
+          this_node.value = "x";
+        }
+      }
+      else if (filter_logic == "less_than"){
+        if (parseFloat(this_node.value) >= parseFloat(filter_value)){
+          this_node.value = "x";
+        }
+      }
+      else if (filter_logic == "greater_or_equal"){
+        if (parseFloat(this_node.value) < parseFloat(filter_value)){
+          this_node.value = "x";
+        }
+      }
+      else if (filter_logic == "less_or_equal"){
+        if (parseFloat(this_node.value) > parseFloat(filter_value)){
+          this_node.value = "x";
+        }
+      }
+    }
   }
 };
 
@@ -1528,6 +1567,12 @@ $('#block_by_index').click(function(){
   block_by_index();
   edit_data_change();
 });
+
+$('#filter_by_value').click(function(){
+  filter_by_value();
+  edit_data_change();
+})
+
 $('#exclude_group').click(edit_data_change);
 $('#block_outliers').click(edit_data_change);
 $('#reset').click(edit_data_change);

--- a/wqflask/wqflask/templates/show_trait_transform_and_filter.html
+++ b/wqflask/wqflask/templates/show_trait_transform_and_filter.html
@@ -20,8 +20,48 @@
     <div id="remove_samples_invalid" class="alert alert-error" style="display:none;">
           Please check that your input is formatted correctly, e.g. <strong>3, 5-10, 12</strong>
     </div>
+    {% if sample_groups[0].attributes %}
+    <div class="input-append block-div-2">
+        <label for="exclude_column">Block samples by group:</label>
+        <select id="exclude_column" size=1>
+          {% for attribute in sample_groups[0].attributes %}
+          {% if sample_groups[0].attributes[attribute].distinct_values|length <= 10 %}
+          <option value="{{ loop.index }}">
+              {{ sample_groups[0].attributes[attribute].name }}
+          </option>
+          {% endif %}
+          {% endfor %}
+        </select>
+        <select id="attribute_values" size=1>
+        </select>
+        <select id="exclude_by_attr_group" size="1">
+          <option value="primary">
+            {{ sample_group_types['samples_primary'] }}
+          </option>
+          <option value="other">
+            {{ sample_group_types['samples_other'] }}
+          </option>
+        </select>
+        <input type="button" id="exclude_by_attr" class="btn btn-danger" value="Block">
+    </div>
+    {% endif %}
     <div id="filterMenuSpan" class="input-append block-div-2">
-      <label for="filter_samples_field">Filter samples by value </label>
+      <label for="filter_samples_field">Filter samples by {% if not sample_groups[0].attributes %}value{% endif %} </label>
+      {% if sample_groups[0].attributes %}
+      <select id="filter_column">
+        <option value="value">Value</option>
+        {% if js_data.se_exists %}
+        <option value="stderr">SE</option>
+        {% endif %}
+        {% for attribute in sample_groups[0].attributes %}
+
+        <option value="{{ loop.index }}">
+          {{ sample_groups[0].attributes[attribute].name }}
+        </option>
+
+        {% endfor %}
+      </select>
+      {% endif %}
       <select id="filter_logic" size="1">
         <option value="greater_than">></option>
         <option value="less_than"><</option>
@@ -39,20 +79,6 @@
       </select>
       <input type="button" id="filter_by_value" class="btn btn-danger" value="Filter">
     </div>
-    {% if sample_groups[0].attributes %}
-    <div class="input-append block-div-2">
-        <label for="exclude_menu">Block samples by group:</label>
-        <select id="exclude_menu" size=1>
-          {% for attribute in sample_groups[0].attributes %}
-          <option value="{{ sample_groups[0].attributes[attribute].name.replace(' ', '_') }}">
-              {{ sample_groups[0].attributes[attribute].name }}</option>
-          {% endfor %}
-        </select>
-        <select id="attribute_values" size=1>
-        </select>
-        <input type="button" id="exclude_group" class="btn" value="Block">
-    </div>
-    {% endif %}
     <div>
       <input type="button" id="hide_no_value" class="btn btn-default" value="Hide No Value">
       <input type="button" id="block_outliers" class="btn btn-default" value="Block Outliers">

--- a/wqflask/wqflask/templates/show_trait_transform_and_filter.html
+++ b/wqflask/wqflask/templates/show_trait_transform_and_filter.html
@@ -4,7 +4,7 @@
         <strong>Reset</strong> option as
         needed.
     </p>
-    <div id="blockMenuSpan" class="input-append block-by-index-div">
+    <div id="blockMenuSpan" class="input-append block-div">
         <label for="remove_samples_field">Block samples by index:</label>
         <input type="text" id="remove_samples_field" placeholder="Example: 3, 5-10, 12">
         <select id="block_group" size="1">
@@ -20,8 +20,27 @@
     <div id="remove_samples_invalid" class="alert alert-error" style="display:none;">
           Please check that your input is formatted correctly, e.g. <strong>3, 5-10, 12</strong>
     </div>
+    <div id="filterMenuSpan" class="input-append block-div-2">
+      <label for="filter_samples_field">Filter samples by value </label>
+      <select id="filter_logic" size="1">
+        <option value="greater_than">></option>
+        <option value="less_than"><</option>
+        <option value="greater_or_equal">≥</option>
+        <option value="less_or_equal">≤</option>
+      </select>
+      <input type="text" id="filter_value" placeholder="Example: 3, 10, 15">
+      <select id="filter_group" size="1">
+        <option value="primary">
+          {{ sample_group_types['samples_primary'] }}
+        </option>
+        <option value="other">
+          {{ sample_group_types['samples_other'] }}
+        </option>
+      </select>
+      <input type="button" id="filter_by_value" class="btn btn-danger" value="Filter">
+    </div>
     {% if sample_groups[0].attributes %}
-    <div class="input-append block-by-attribute-div">
+    <div class="input-append block-div-2">
         <label for="exclude_menu">Block samples by group:</label>
         <select id="exclude_menu" size=1>
           {% for attribute in sample_groups[0].attributes %}


### PR DESCRIPTION
#### Description
This PR adds the option to filter sample values, SEs, and case attributes (the extra cofactor columns) using >, <, ≥, and ≤.

It seems to work correctly, but I want to somehow simplify the interface because the "Transform and Filter" tab has too many options clustered in it now.

#### How should this be tested?
Load any trait page (like the one below), go to the "Transform and Filter Data" tab, and try the "Filter samples by" option.

https://genenetwork.org/show_trait?trait_id=10011&dataset=BXD-LongevityPublish

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions
