### PR TITLE
Feature/default scatterplot tab

### DIFF
--- a/wqflask/wqflask/correlation/corr_scatter_plot.py
+++ b/wqflask/wqflask/correlation/corr_scatter_plot.py
@@ -29,6 +29,8 @@ class CorrScatterPlot(object):
         self.trait_2 = create_trait(name=params['trait_2'], dataset=self.dataset_2)
         #self.trait_3 = create_trait(name=params['trait_3'], dataset=self.dataset_3)
 
+        self.method = params['method']
+
         primary_samples = self.dataset_1.group.samplelist
         if self.dataset_1.group.parlist != None:
             primary_samples += self.dataset_1.group.parlist

--- a/wqflask/wqflask/templates/corr_scatterplot.html
+++ b/wqflask/wqflask/templates/corr_scatterplot.html
@@ -118,17 +118,17 @@
   {% endif %}
 
   <ul class="nav nav-tabs">
-    <li class="active">
+    <li {% if method == 'pearson' %}class="active"{% endif %}>
       <a href="#tp1" data-toggle="tab">Pearson</a>
     </li>
-    <li>
+    <li {% if method == 'spearman' %}class="active"{% endif %}>
       <a href="#tp2" data-toggle="tab">Spearman Rank</a>
     </li>
   </ul>
 
   <div class="tab-content" style="min-width: 800px;">
 
-    <div class="tab-pane active" id="tp1">
+    <div class="tab-pane {% if method == 'pearson' %}active{% endif %}" id="tp1">
       <br>
       <div id="scatterplot2"></div>
       <br>
@@ -243,7 +243,7 @@
       </div>
     </div>
 
-    <div class="tab-pane" id="tp2">
+    <div class="tab-pane {% if method == 'spearman' %}active{% endif %}" id="tp2">
       <br>
       <div id="srscatterplot2"></div>
       <br>

--- a/wqflask/wqflask/templates/correlation_matrix.html
+++ b/wqflask/wqflask/templates/correlation_matrix.html
@@ -32,6 +32,7 @@
       {% endfor %}
     </tr>
     {% for trait in traits %}
+    {% set outer_loop = loop.index %}
     <tr>
       <td align="center"><input type="checkbox" class="checkbox" style="margin-left: 3px; margin-right: 1px;"></td>
       <td align="right" style="padding-right: 4px;" >
@@ -54,7 +55,7 @@
       {% if result[1] == 0 %}
       <td nowrap="ON" align="middle" bgcolor="#eeeeee" style="padding: 3px; line-height: 1.1;">N/A</td>
       {% else %}
-      <td nowrap="ON" align="middle" class="corr_cell" style="padding: 3px; line-height: 1.1;"><a href="/corr_scatter_plot?dataset_1={% if trait.dataset.name == 'Temp' %}Temp_{{ trait.dataset.group.name }}{% else %}{{ trait.dataset.name }}{% endif %}&dataset_2={% if result[0].dataset.name == 'Temp' %}Temp_{{ result[0].dataset.group.name }}{% else %}{{ result[0].dataset.name }}{% endif %}&trait_1={{ trait.name }}&trait_2={{ result[0].name }}"><font style="font-size: 12px; color: #3071a9; font-weight: bold;" ><span class="corr_value">{{ '%0.2f' % result[1] }}</span><br>{{ result[2] }}</font></a></td>
+      <td nowrap="ON" align="middle" class="corr_cell" style="padding: 3px; line-height: 1.1;"><a href="/corr_scatter_plot?method={% if loop.index > outer_loop %}spearman{% else %}pearson{% endif %}&dataset_1={% if trait.dataset.name == 'Temp' %}Temp_{{ trait.dataset.group.name }}{% else %}{{ trait.dataset.name }}{% endif %}&dataset_2={% if result[0].dataset.name == 'Temp' %}Temp_{{ result[0].dataset.group.name }}{% else %}{{ result[0].dataset.name }}{% endif %}&trait_1={{ trait.name }}&trait_2={{ result[0].name }}"><font style="font-size: 12px; color: #3071a9; font-weight: bold;" ><span class="corr_value">{{ '%0.2f' % result[1] }}</span><br>{{ result[2] }}</font></a></td>
       {% endif %}
       {% endif %}
       {% endfor %}

--- a/wqflask/wqflask/templates/correlation_page.html
+++ b/wqflask/wqflask/templates/correlation_page.html
@@ -349,7 +349,7 @@
                       'orderSequence': [ "desc", "asc"],
                       'render': function(data, type, row, meta) {
                         if (data.sample_r != "N/A") {
-                          return "<a target\"_blank\" href=\"corr_scatter_plot?dataset_1={% if dataset.name == 'Temp' %}Temp_{{ dataset.group.name }}{% else %}{{ dataset.name }}{% endif %}&dataset_2=" + data.dataset + "&trait_1={{ this_trait.name }}&trait_2=" + data.trait_id + "\">" + data.sample_r + "</a>"
+                          return "<a target\"_blank\" href=\"corr_scatter_plot?method={% if corr_method == 'spearman' %}spearman{% else %}pearson{% endif %}&dataset_1={% if dataset.name == 'Temp' %}Temp_{{ dataset.group.name }}{% else %}{{ dataset.name }}{% endif %}&dataset_2=" + data.dataset + "&trait_1={{ this_trait.name }}&trait_2=" + data.trait_id + "\">" + data.sample_r + "</a>"
                         } else {
                           return data.sample_r
                         }
@@ -470,7 +470,7 @@
                       'orderSequence': [ "desc", "asc"],
                       'render': function(data, type, row, meta) {
                         if (data.sample_r != "N/A") {
-                          return "<a target\"_blank\" href=\"corr_scatter_plot?dataset_1={% if dataset.name == 'Temp' %}Temp_{{ dataset.group.name }}{% else %}{{ dataset.name }}{% endif %}&dataset_2=" + data.dataset + "&trait_1={{ this_trait.name }}&trait_2=" + data.trait_id + "\">" + data.sample_r + "</a>"
+                          return "<a target\"_blank\" href=\"corr_scatter_plot?method={% if corr_method == 'spearman' %}spearman{% else %}pearson{% endif %}&dataset_1={% if dataset.name == 'Temp' %}Temp_{{ dataset.group.name }}{% else %}{{ dataset.name }}{% endif %}&dataset_2=" + data.dataset + "&trait_1={{ this_trait.name }}&trait_2=" + data.trait_id + "\">" + data.sample_r + "</a>"
                         } else {
                           return data.sample_r
                         }
@@ -524,7 +524,7 @@
                       'orderSequence': [ "desc", "asc"],
                       'render': function(data, type, row, meta) {
                         if (data.sample_r != "N/A") {
-                          return "<a target\"_blank\" href=\"corr_scatter_plot?dataset_1={% if dataset.name == 'Temp' %}Temp_{{ dataset.group.name }}{% else %}{{ dataset.name }}{% endif %}&dataset_2=" + data.dataset + "&trait_1={{ this_trait.name }}&trait_2=" + data.trait_id + "\">" + data.sample_r + "</a>"
+                          return "<a target\"_blank\" href=\"corr_scatter_plot?method={% if corr_method == 'spearman' %}spearman{% else %}pearson{% endif %}&dataset_1={% if dataset.name == 'Temp' %}Temp_{{ dataset.group.name }}{% else %}{{ dataset.name }}{% endif %}&dataset_2=" + data.dataset + "&trait_1={{ this_trait.name }}&trait_2=" + data.trait_id + "\">" + data.sample_r + "</a>"
                         } else {
                           return data.sample_r
                         }


### PR DESCRIPTION
#### Description
This PR makes any scatter-plot links from a Spearman correlation default to the Spearman scatter-plot. Previously it would just default to Pearson while having a tab for both methods.

#### How should this be tested?
Open a scatterplot from either the Correlation Matrix or Correlation Results pages

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions

<!-- Are there any questions for the reviewer -->
