### PR TITLE
Added an export for the Correlation Matrix

### DIFF
--- a/wqflask/wqflask/templates/correlation_matrix.html
+++ b/wqflask/wqflask/templates/correlation_matrix.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
+{% block title %}Correlation Matrix{% endblock %}
 {% block css %}
     <link rel="stylesheet" type="text/css" href="{{ url_for('css', filename='DataTables/css/jquery.dataTables.css') }}" />
     <link rel="stylesheet" type="text/css" href="/static/new/css/corr_matrix.css" />
     <link rel="stylesheet" type="text/css" href="/static/new/css/show_trait.css" />
     <link rel="stylesheet" type="text/css" href="/static/new/css/panelutil.css" />
-     <link rel="stylesheet" type="text/css" href="{{ url_for('css', filename='d3-tip/d3-tip.css') }}" />
+    <link rel="stylesheet" type="text/css" href="{{ url_for('css', filename='d3-tip/d3-tip.css') }}" />
 {% endblock %}
 {% block content %}
 
@@ -62,6 +63,12 @@
     {% endfor %}
   </tbody>
 </table>
+<br>
+<form method="post" target="_blank" action="/export_corr_matrix" id="matrix_export_form">
+  <input type="hidden" name="export_filepath" value="{{ export_filepath }}">
+  <input type="hidden" name="export_filename" value="{{ export_filename }}">
+  <button class="btn btn-default" id="export">Download <span class="glyphicon glyphicon-download"></span></button>
+</form>
 <br>
 {% if pca_works == "True" %}
 <h2>PCA Traits</h2>
@@ -172,6 +179,14 @@
         "paging": false,
         "orderClasses": true
       } );
+
+      export_corr_matrix = function() {
+            $('#matrix_export_form').attr('action', '/export_corr_matrix');
+            return $('#matrix_export_form').submit();
+      }
+
+      $('#export').click(export_corr_matrix);
+
     </script>
 
 {% endblock %}

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -799,6 +799,17 @@ def export_mapping_results():
 
     return response
 
+@app.route("/export_corr_matrix", methods = ('POST',))
+def export_corr_matrix():
+    file_path = request.form.get("export_filepath")
+    file_name = request.form.get("export_filename")
+    results_csv = open(file_path, "r").read()
+    response = Response(results_csv,
+                        mimetype='text/csv',
+                        headers={"Content-Disposition":"attachment;filename=" + file_name + ".csv"})
+
+    return response
+
 @app.route("/export", methods = ('POST',))
 def export():
     logger.info("request.form:", request.form)


### PR DESCRIPTION
#### Description
This PR adds a CSV export for the correlation matrix (currently just modeled after GN1's export).

At some point all exports should probably be changed to use the same path. Currently /export_corr_matrix and /export_mapping_results work in the same way, so it should be possible to create a generic endpoint that takes a filepath and filename as input.

#### How should this be tested?
Load any Correlation Matrix and click the Download button under it.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions

