### PR TITLE
Feature/add location type correlation option

### DIFF
--- a/wqflask/wqflask/correlation/show_corr_results.py
+++ b/wqflask/wqflask/correlation/show_corr_results.py
@@ -101,11 +101,12 @@ class CorrelationResults(object):
                 'min_loc_mb' in start_vars and
                 'max_loc_mb' in start_vars):
 
+                self.location_type = get_string(start_vars, 'location_type')
                 self.location_chr = get_string(start_vars, 'loc_chr')
                 self.min_location_mb = get_int(start_vars, 'min_loc_mb')
                 self.max_location_mb = get_int(start_vars, 'max_loc_mb')
             else:
-                self.location_chr = self.min_location_mb = self.max_location_mb = None
+                self.location_type = self.location_chr = self.min_location_mb = self.max_location_mb = None
 
             self.get_formatted_corr_type()
             self.return_number = int(start_vars['corr_return_results'])
@@ -173,23 +174,25 @@ class CorrelationResults(object):
             self.correlation_data = collections.OrderedDict(sorted(list(self.correlation_data.items()),
                                                                    key=lambda t: -abs(t[1][0])))
 
-            if self.target_dataset.type == "ProbeSet" or self.target_dataset.type == "Geno":
-                #ZS: Convert min/max chromosome to an int for the location range option
-                range_chr_as_int = None
-                for order_id, chr_info in list(self.dataset.species.chromosomes.chromosomes.items()):
-                    if 'loc_chr' in start_vars:
-                        if chr_info.name == self.location_chr:
-                            range_chr_as_int = order_id
+
+            #ZS: Convert min/max chromosome to an int for the location range option
+            range_chr_as_int = None
+            for order_id, chr_info in list(self.dataset.species.chromosomes.chromosomes.items()):
+                if 'loc_chr' in start_vars:
+                    if chr_info.name == self.location_chr:
+                        range_chr_as_int = order_id
 
             for _trait_counter, trait in enumerate(list(self.correlation_data.keys())[:self.return_number]):
                 trait_object = create_trait(dataset=self.target_dataset, name=trait, get_qtl_info=True, get_sample_info=False)
                 if not trait_object:
                     continue
 
-                if self.target_dataset.type == "ProbeSet" or self.target_dataset.type == "Geno":
-                    #ZS: Convert trait chromosome to an int for the location range option
-                    chr_as_int = 0
-                    for order_id, chr_info in list(self.dataset.species.chromosomes.chromosomes.items()):
+                chr_as_int = 0
+                for order_id, chr_info in list(self.dataset.species.chromosomes.chromosomes.items()):
+                    if self.location_type == "highest_lod":
+                        if chr_info.name == trait_object.locus_chr:
+                            chr_as_int = order_id
+                    else:
                         if chr_info.name == trait_object.chr:
                             chr_as_int = order_id
 
@@ -199,9 +202,15 @@ class CorrelationResults(object):
                     if (self.target_dataset.type == "ProbeSet" or self.target_dataset.type == "Publish") and bool(trait_object.mean):
                         if (self.min_expr != None) and (float(trait_object.mean) < self.min_expr):
                             continue
-                    if self.target_dataset.type == "ProbeSet" or self.target_dataset.type == "Geno":
-                        if range_chr_as_int != None and (chr_as_int != range_chr_as_int):
+
+                    if range_chr_as_int != None and (chr_as_int != range_chr_as_int):
+                        continue
+                    if self.location_type == "highest_lod":
+                        if (self.min_location_mb != None) and (float(trait_object.locus_mb) < float(self.min_location_mb)):
                             continue
+                        if (self.max_location_mb != None) and (float(trait_object.locus_mb) > float(self.max_location_mb)):
+                            continue
+                    else:
                         if (self.min_location_mb != None) and (float(trait_object.mb) < float(self.min_location_mb)):
                             continue
                         if (self.max_location_mb != None) and (float(trait_object.mb) > float(self.max_location_mb)):

--- a/wqflask/wqflask/static/new/javascript/show_trait.js
+++ b/wqflask/wqflask/static/new/javascript/show_trait.js
@@ -519,21 +519,26 @@ $('select[name=corr_type]').change(on_corr_method_change);
 
 on_dataset_change = function() {
   let dataset_type = $('select[name=corr_dataset] option:selected').data('type');
+  let location_type = $('select[name=location_type] option:selected').val();
 
   if (dataset_type == "mrna_assay"){
     $('#min_expr_filter').show();
-    $('#location_filter').show();
+    $('select[name=location_type] option:disabled').prop('disabled', false)
   }
   else if (dataset_type == "pheno"){
     $('#min_expr_filter').show();
-    $('#location_filter').hide();
+    $('select[name=location_type]>option:eq(0)').prop('disabled', true).attr('selected', false);
+    $('select[name=location_type]>option:eq(1)').prop('disabled', false).attr('selected', true);
   }
   else {
     $('#min_expr_filter').hide();
-    $('#location_filter').show();
+    $('select[name=location_type]>option:eq(0)').prop('disabled', false).attr('selected', true);
+    $('select[name=location_type]>option:eq(1)').prop('disabled', true).attr('selected', false);
   }
 }
+
 $('select[name=corr_dataset]').change(on_dataset_change);
+$('select[name=location_type]').change(on_dataset_change);
 
 submit_special = function(url) {
   get_table_contents_for_form_submit("trait_data_form");

--- a/wqflask/wqflask/static/new/javascript/show_trait.js
+++ b/wqflask/wqflask/static/new/javascript/show_trait.js
@@ -566,7 +566,7 @@ get_table_contents_for_form_submit = function(form_id) {
 }
 
 var corr_input_list = ['corr_type', 'primary_samples', 'trait_id', 'dataset', 'group', 'tool_used', 'form_url', 'corr_sample_method', 'corr_samples_group', 'corr_dataset', 'min_expr',
-                        'corr_return_results', 'loc_chr', 'min_loc_mb', 'max_loc_mb', 'p_range_lower', 'p_range_upper']
+                        'corr_return_results', 'location_type', 'loc_chr', 'min_loc_mb', 'max_loc_mb', 'p_range_lower', 'p_range_upper']
 
 $(".corr_compute").on("click", (function(_this) {
   return function() {

--- a/wqflask/wqflask/templates/show_trait_calculate_correlations.html
+++ b/wqflask/wqflask/templates/show_trait_calculate_correlations.html
@@ -84,12 +84,12 @@
             <label for="location_type" class="col-xs-2 control-label">Location Type</label>
             <div class="col-xs-4 controls">
                 <select name="location_type" class="form-control">
-                    {% if dataset.type != 'Publish' %}<option value="gene">Gene</option>{% endif %}
+                    <option value="gene" {% if dataset.type == 'Publish' %}disabled{% endif %}>Gene</option>
                     <option value="highest_lod">Highest LOD</option>
                 </select>
             </div>
         </div>
-        <div id="location_filter" class="form-group" style="display: {% if dataset.type != 'Publish' %}block{% else %}none{% endif %};">
+        <div id="location_filter" class="form-group">
               <label class="col-xs-2 control-label">Location</label>
               <div class="col-xs-6 controls">
                   <span>

--- a/wqflask/wqflask/templates/show_trait_calculate_correlations.html
+++ b/wqflask/wqflask/templates/show_trait_calculate_correlations.html
@@ -80,6 +80,15 @@
                 <input name="min_expr" value="" type="text" class="form-control min-expr-field">
             </div>
         </div>
+        <div class="form-group">
+            <label for="location_type" class="col-xs-2 control-label">Location Type</label>
+            <div class="col-xs-4 controls">
+                <select name="location_type" class="form-control">
+                    {% if dataset.type != 'Publish' %}<option value="gene">Gene</option>{% endif %}
+                    <option value="highest_lod">Highest LOD</option>
+                </select>
+            </div>
+        </div>
         <div id="location_filter" class="form-group" style="display: {% if dataset.type != 'Publish' %}block{% else %}none{% endif %};">
               <label class="col-xs-2 control-label">Location</label>
               <div class="col-xs-6 controls">


### PR DESCRIPTION
#### Description
This PR adds a "Location Type" option to the trait page correlation options.

This option lets the user choose between using the trait's location (gene/snp location) or the location of the peak LOD score when filtering correlation results by location. For example, selecting "Highest LOD" and then putting "5" in the "Chr" location field will only show results with Peak LOD in chromosome 5.

#### How should this be tested?
Do correlations from any trait page and try different combinations of the Database, Location Type, and Location fields. For example this trait - https://genenetwork.org/show_trait?trait_id=1436869_at&dataset=HC_M2_0606_P

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions

