### PR TITLE
Feature/swap legend metadata positions

### DIFF
--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -860,7 +860,10 @@ class DisplayMappingResults(object):
                            text='%2.1f'%item, font=bootScaleFont, fill=BLACK)
 
         if self.legendChecked:
-            startPosY = 30
+            if hasattr(self.traitList[0], 'chr') and hasattr(self.traitList[0], 'mb'):
+                startPosY = 30
+            else:
+                startPosY = 15
             smallLabelFont = ImageFont.truetype(font=TREBUC_FILE, size=12*fontZoom)
             leftOffset = canvas.size[0] - xRightOffset - 190
             im_drawer.rectangle(
@@ -941,28 +944,6 @@ class DisplayMappingResults(object):
             traitPixel = ((locPixel, yZero), (locPixel-7, yZero+14), (locPixel+7, yZero+14))
             draw_open_polygon(canvas, xy=traitPixel, outline=BLACK,
                               fill=self.TRANSCRIPT_LOCATION_COLOR)
-
-        if self.legendChecked:
-            startPosY = 15
-            nCol = 2
-            smallLabelFont = ImageFont.truetype(font=TREBUC_FILE, size=12*fontZoom)
-            if self.manhattan_plot:
-                leftOffset = xLeftOffset
-            else:
-                leftOffset = xLeftOffset+(nCol-1)*200*fontZoom
-            draw_open_polygon(
-                canvas,
-                xy=(
-                    (leftOffset+7, startPosY-7),
-                    (leftOffset, startPosY+7),
-                    (leftOffset+14, startPosY+7)),
-                outline=BLACK, fill=self.TRANSCRIPT_LOCATION_COLOR
-            )
-            TEXT_Y_DISPLACEMENT = -8
-            im_drawer.text(
-                text="Sequence Site",
-                xy=(leftOffset+15, startPosY+TEXT_Y_DISPLACEMENT), font=smallLabelFont,
-                fill=self.TOP_RIGHT_INFO_COLOR)
 
     def drawSNPTrackNew(self, canvas, offset= (40, 120, 80, 10), zoom = 1, startMb = None, endMb = None):
         im_drawer = ImageDraw.Draw(canvas)
@@ -1060,17 +1041,38 @@ class DisplayMappingResults(object):
         labelFont=ImageFont.truetype(font=TREBUC_FILE, size=12*fontZoom)
         startPosY = 15
         stepPosY = 12*fontZoom
+
+        startPosX = canvas.size[0] - xRightOffset - 415
+        if hasattr(self.traitList[0], 'chr') and hasattr(self.traitList[0], 'mb'):
+            startPosY = 15
+            nCol = 2
+            smallLabelFont = ImageFont.truetype(font=TREBUC_FILE, size=12*fontZoom)
+
+            leftOffset = canvas.size[0] - xRightOffset - 190
+            draw_open_polygon(
+                canvas,
+                xy=(
+                    (leftOffset + 6, startPosY-7),
+                    (leftOffset - 1, startPosY+7),
+                    (leftOffset + 13, startPosY+7)),
+                outline=BLACK, fill=self.TRANSCRIPT_LOCATION_COLOR
+            )
+            TEXT_Y_DISPLACEMENT = -8
+            im_drawer.text(
+                text="Sequence Site",
+                xy=(leftOffset + 20, startPosY+TEXT_Y_DISPLACEMENT), font=smallLabelFont,
+                fill=self.TOP_RIGHT_INFO_COLOR)
+
         if self.manhattan_plot != True:
             im_drawer.line(
-                xy=((xLeftOffset, startPosY), (xLeftOffset+32, startPosY)),
+                xy=((startPosX, startPosY), (startPosX+32, startPosY)),
                 fill=self.LRS_COLOR, width=2)
             im_drawer.text(
-                text=self.LRS_LOD, xy=(xLeftOffset+40, startPosY+TEXT_Y_DISPLACEMENT),
+                text=self.LRS_LOD, xy=(startPosX+40, startPosY+TEXT_Y_DISPLACEMENT),
                 font=labelFont, fill=BLACK)
             startPosY += stepPosY
 
         if self.additiveChecked:
-            startPosX = canvas.size[0] - xRightOffset - 400
             im_drawer.line(
                 xy=((startPosX, startPosY), (startPosX+17, startPosY)),
                 fill=self.ADDITIVE_COLOR_POSITIVE, width=2)
@@ -1080,10 +1082,9 @@ class DisplayMappingResults(object):
             im_drawer.text(
                 text='Additive Effect', xy=(startPosX+40, startPosY+TEXT_Y_DISPLACEMENT),
                 font=labelFont, fill=BLACK)
+            startPosY += stepPosY
 
         if self.genotype.type == 'intercross' and self.dominanceChecked:
-            startPosX = canvas.size[0] - xRightOffset - 400
-            startPosY += stepPosY
             im_drawer.line(
                 xy=((startPosX, startPosY), (startPosX+17, startPosY)),
                 fill=self.DOMINANCE_COLOR_POSITIVE, width=4)
@@ -1093,44 +1094,42 @@ class DisplayMappingResults(object):
             im_drawer.text(
                 text='Dominance Effect', xy=(startPosX+42, startPosY+5),
                 font=labelFont, fill=BLACK)
+            startPosY += stepPosY
 
         if self.haplotypeAnalystChecked:
-            startPosY += stepPosY
-            startPosX = canvas.size[0] - xRightOffset - 400
             im_drawer.line(
-                xy=((startPosX, startPosY), (startPosX+17, startPosY)),
+                xy=((startPosX-34, startPosY), (startPosX-17, startPosY)),
                 fill=self.HAPLOTYPE_POSITIVE, width=4)
             im_drawer.line(
-                xy=((startPosX+18, startPosY), (startPosX+35, startPosY)),
+                xy=((startPosX-17, startPosY), (startPosX, startPosY)),
                 fill=self.HAPLOTYPE_NEGATIVE, width=4)
             im_drawer.line(
-                xy=((startPosX+36, startPosY), (startPosX+53, startPosY)),
+                xy=((startPosX, startPosY), (startPosX+17, startPosY)),
                 fill=self.HAPLOTYPE_HETEROZYGOUS, width=4)
             im_drawer.line(
-                xy=((startPosX+54, startPosY), (startPosX+67, startPosY)),
+                xy=((startPosX+17, startPosY), (startPosX+34, startPosY)),
                 fill=self.HAPLOTYPE_RECOMBINATION, width=4)
             im_drawer.text(
                 text='Haplotypes (Pat, Mat, Het, Unk)',
-                xy=(startPosX+76, startPosY+5), font=labelFont, fill=BLACK)
+                xy=(startPosX+41, startPosY+TEXT_Y_DISPLACEMENT), font=labelFont, fill=BLACK)
+            startPosY += stepPosY
 
         if self.permChecked and self.nperm > 0:
-            startPosY += stepPosY
-            if self.bootChecked and not self.multipleInterval:
-                startPosX = canvas.size[0] - xRightOffset - 400
-            else:
-                startPosX = canvas.size[0] - xRightOffset - 190
+            thisStartX = startPosX
+            if self.multipleInterval and not self.bootChecked:
+                thisStartX = canvas.size[0] - xRightOffset - 205
             im_drawer.line(
-                xy=((startPosX, startPosY), ( startPosX + 32, startPosY)),
+                xy=((thisStartX, startPosY), ( startPosX + 32, startPosY)),
                 fill=self.SIGNIFICANT_COLOR, width=self.SIGNIFICANT_WIDTH)
             im_drawer.line(
-                xy=((startPosX, startPosY + stepPosY), ( startPosX + 32, startPosY + stepPosY)),
+                xy=((thisStartX, startPosY + stepPosY), ( startPosX + 32, startPosY + stepPosY)),
                 fill=self.SUGGESTIVE_COLOR, width=self.SUGGESTIVE_WIDTH)
             im_drawer.text(
                 text='Significant %s = %2.2f' % (self.LRS_LOD, self.significant),
-                xy=(startPosX+42, startPosY+TEXT_Y_DISPLACEMENT), font=labelFont, fill=BLACK)
+                xy=(thisStartX+40, startPosY+TEXT_Y_DISPLACEMENT), font=labelFont, fill=BLACK)
             im_drawer.text(
                 text='Suggestive %s = %2.2f' % (self.LRS_LOD, self.suggestive),
-                xy=(startPosX+42, startPosY + TEXT_Y_DISPLACEMENT +stepPosY), font=labelFont,
+                xy=(thisStartX+40, startPosY + TEXT_Y_DISPLACEMENT +stepPosY), font=labelFont,
                 fill=BLACK)
 
         labelFont = ImageFont.truetype(font=VERDANA_FILE, size=12*fontZoom)

--- a/wqflask/wqflask/marker_regression/run_mapping.py
+++ b/wqflask/wqflask/marker_regression/run_mapping.py
@@ -138,15 +138,15 @@ class RunMapping(object):
             mapping_results_filename = self.dataset.group.name + "_" + ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(6))
             self.mapping_results_path = "{}{}.csv".format(webqtlConfig.GENERATED_IMAGE_DIR, mapping_results_filename)
 
-        if start_vars['manhattan_plot']:
-            self.color_scheme = "alternating"
-            if "color_scheme" in start_vars:
-                self.color_scheme = start_vars['color_scheme']
-                if self.color_scheme == "single":
-                    self.manhattan_single_color = start_vars['manhattan_single_color']
-            self.manhattan_plot = True
-        else:
-            self.manhattan_plot = False
+        self.manhattan_plot = False
+        if 'manhattan_plot' in start_vars:
+            if start_vars['manhattan_plot'].lower() != "false":
+                self.color_scheme = "alternating"
+                if "color_scheme" in start_vars:
+                    self.color_scheme = start_vars['color_scheme']
+                    if self.color_scheme == "single":
+                        self.manhattan_single_color = start_vars['manhattan_single_color']
+                self.manhattan_plot = True
 
         self.maf = start_vars['maf'] # Minor allele frequency
         if "use_loco" in start_vars:

--- a/wqflask/wqflask/templates/show_trait.html
+++ b/wqflask/wqflask/templates/show_trait.html
@@ -146,7 +146,7 @@
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/scientific.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/natural.js') }}"></script>
-    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/scroller/js/scroller.dataTables.min.js') }}"></script>
+    <script language="javascript" type="text/javascript" src="https://cdn.datatables.net/scroller/2.0.3/js/dataTables.scroller.min.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='nouislider/nouislider.js') }}"></script>
     <script type="text/javascript" src="/static/new/javascript/initialize_show_trait_tables.js"></script>
     <script type="text/javascript" src="/static/new/javascript/show_trait_mapping_tools.js"></script>


### PR DESCRIPTION
#### Description
This PR swaps the position of metadata and the legend in the mapping results figure.

I think this is mainly because metadata can be wider (so it has more space to expand if it's on the left) and is generally more important, and legends are more typically on the right.


#### How should this be tested?
Do mapping from any trait page and look at the figure to see if it looks okay.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)

#### Questions

<!-- Are there any questions for the reviewer -->
