### PR TITLE
Feature/add scroller to search results

### DIFF
--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -3,7 +3,6 @@
 {% block css %}
     <link rel="stylesheet" type="text/css" href="{{ url_for('css', filename='DataTables/css/jquery.dataTables.css') }}" />
     <link rel="stylesheet" type="text/css" href="{{ url_for('css', filename='fontawesome/css/font-awesome.min.css') }}" />
-    <link rel="stylesheet" type="text/css" href="{{ url_for('js', filename='DataTablesExtensions/scrollerStyle/css/scroller.dataTables.min.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('js', filename='DataTablesExtensions/buttonStyles/css/buttons.dataTables.min.css') }}">
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css">
     <link rel="stylesheet" type="text/css" href="/static/new/css/show_trait.css" />
@@ -125,7 +124,7 @@
             {% endif %}
           </div>
           {% endif %}
-          <div id="table_container" {% if dataset.type == 'ProbeSet' or dataset.type == 'Publish' %}style="min-width: 1500px;"{% endif %}>
+          <div id="table_container" {% if dataset.type == 'ProbeSet' or dataset.type == 'Publish' %}style="min-width: 1500px; max-width:100%;"{% endif %}>
             <table class="table-hover table-striped cell-border" id='trait_table' style="float: left; width: {% if dataset.type == 'Geno' %}380px{% else %}100%{% endif %};">
                 <tbody>
                  <td colspan="100%" align="center"><br><b><font size="15">Loading...</font></b><br></td>
@@ -310,7 +309,6 @@
                     {
                       'title': "Description",
                       'type': "natural",
-                      'width': "500px",
                       'data': null,
                       'render': function(data, type, row, meta) {
 			                  try {

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -146,6 +146,7 @@
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='js_alt/md5.min.js') }}"></script>
 
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
+    <script language="javascript" type="text/javascript" src="https://cdn.datatables.net/scroller/2.0.2/js/dataTables.scroller.min.js"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='jszip/jszip.min.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/natural.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/buttons/js/dataTables.buttons.min.js') }}"></script>
@@ -383,36 +384,16 @@
                     }{% endif %}
                 ],
                 "order": [[1, "asc" ]],
-                {% if dataset.type != 'Geno' %}
-                buttons: [
-                    {
-                        extend: 'columnsToggle',
-                        columns: function( idx, data, node ) {
-                          if (idx != 0) {
-                            return true;
-                          } else {
-                            return false;
-                          }
-                        },
-                        postfixButtons: [ 'colvisRestore' ]
-                    }
-                ],
-                'sDom': "Bpitirp",
-                {% else %}
-                'sDom': "pitirp",
-                {% endif %}
-                'iDisplayLength': 500,
-                'deferRender': true,
-                'paging': true,
-                'orderClasses': true,
-                'processing': true,
-                'bServerSide': true,
-                'sAjaxSource': '/search_table'+getParams(window.location.href),
-                'infoCallback': function(settings, start, end, max, total, pre) {
-                  return "Showing " + start + " to " + (start + this.api().data().length - 1) + " of " + total + " entries";
-                }
+                'sDom': "itir",
+                "autoWidth": true,
+                "bSortClasses": false,
+                "scrollY": "100vh",
+                "scroller":  true,
+                "scrollCollapse": true
             } );
             
+            trait_table.draw(); //ZS: This makes the table adjust its height properly on initial load
+
             $('.toggle-vis').on( 'click', function (e) {
               e.preventDefault();
 


### PR DESCRIPTION
#### Description
This adds Scroller to the search result table and removes pagination.

#### How should this be tested?
Do any search and check that the result table works as expected. For example - https://genenetwork.org/search?species=mouse&group=BXD&type=Phenotypes&dataset=BXDPublish&search_terms_or=cocaine+nicotine+opiates+thc&search_terms_and=&FormID=searchResult

#### Any background context you want to provide?
Not really background context, but while doing this I noticed that the Scroller CSS file forces text onto one line, which is what caused the problems I had a while back with trying to add Scroller to the correlation page. It still seems to work fine without that CSS file, but it might be worth keeping this in mind.

#### What are the relevant pivotal tracker stories?
N/A

#### Screenshots (if appropriate)
N/A

#### Questions

