### PR TITLE
Fix the way temp traits are displayed when selecting covariates from a collection

### DIFF
--- a/wqflask/base/trait.py
+++ b/wqflask/base/trait.py
@@ -337,6 +337,10 @@ def jsonable(trait):
                     dataset_name=dataset.shortname,
                     location=trait.location_repr
                     )
+    elif dataset.name == "Temp":
+        return dict(name=trait.name,
+                    dataset="Temp",
+                    dataset_name="Temp")
     else:
         return dict()
 


### PR DESCRIPTION
#### Description
The function "jsonable" in trait.py did not account for temp traits, causing them to not display correctly when you attempt to select them as covariates for mapping. I probably should have included this in the previous PR since it's part of fixing temp trait covariate mapping.

#### How should this be tested?
Try to select temp traits as covariates for mapping (or as cofactors on a scatterplot).

#### Any background context you want to provide?


#### What are the relevant pivotal tracker stories?


#### Screenshots (if appropriate)

#### Questions

