### PR TITLE
Feature/add UI for editing metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   unittest:
     runs-on: ubuntu-latest
-    container: bonfacekilz/python3-genenetwork2:00ba1f8
+    container: bonfacekilz/genenetwork2:latest
 
     steps:
     # First start with mariadb set then checkout. The checkout gives

--- a/doc/docker-container.org
+++ b/doc/docker-container.org
@@ -32,13 +32,13 @@ First create the gn2 tar archive by running:
 env GUIX_PACKAGE_PATH="/home/bonface/projects/guix-bioinformatics:/home/bonface/projects/guix-past/modules" \
     ./pre-inst-env guix pack --no-grafts\
     -S /gn2-profile=/ \
-    screen genenetwork2
+    screen python2-genenetwork2
 
 # For the Python 3 version:
 env GUIX_PACKAGE_PATH="/home/bonface/projects/guix-bioinformatics:/home/bonface/projects/guix-past/modules" \
     ./pre-inst-env guix pack --no-grafts\
     -S /gn2-profile=/ \
-    screen python3-genenetwork2
+    screen genenetwork2
   #+end_src
 
 The output will look something similar to:
@@ -59,16 +59,16 @@ RUN tar -xzf /tmp/gn2.tar.gz -C / && rm -f /tmp/gn2.tar.gz && \
 
 Build the image(Note the fullstop at the end):
 
-: sudo docker build -t python3-genenetwork2:latest -f Dockerfile .
+: sudo docker build -t genenetwork2:latest -f Dockerfile .
 
 To load the image interactively you've just created:
 
-: docker run -ti "python3-genenetwork2:latest" bash
+: docker run -ti "genenetwork2:latest" bash
 
 Assuming you have a docker instance running, you could always run
 commands in it e.g:
 
-: docker run "python2-genenetwork2:latest" python --version 
+: docker run "genenetwork2:latest" python --version
 
 * Pushing to DockerHub
 
@@ -78,7 +78,7 @@ CI environment using Github Actions.
 To push to dockerhub, first get the image name by running =docker
 images=. Push to dockerhub using a command similar to:
 
-: docker push bonfacekilz/python3-genenetwork2:latest
+: docker push bonfacekilz/genenetwork2:latest
 
 Right now, we have 2 images on DockerHub:
 

--- a/wqflask/db/webqtlDatabaseFunction.py
+++ b/wqflask/db/webqtlDatabaseFunction.py
@@ -21,10 +21,6 @@
 # This module is used by GeneNetwork project (www.genenetwork.org)
 
 from db.call import fetch1
-from utility.tools import USE_GN_SERVER
-
-from utility.logger import getLogger
-logger = getLogger(__name__)
 
 ###########################################################################
 # output: cursor instance
@@ -38,13 +34,10 @@ def retrieve_species(group):
     """
     result = fetch1("select Species.Name from Species, InbredSet where InbredSet.Name = '%s' and InbredSet.SpeciesId = Species.Id" % (
         group), "/cross/" + group + ".json", lambda r: (r["species"],))[0]
-    logger.debug("retrieve_species result:", result)
     return result
 
 
 def retrieve_species_id(group):
-
     result = fetch1("select SpeciesId from InbredSet where Name = '%s'" % (
         group), "/cross/" + group + ".json", lambda r: (r["species_id"],))[0]
-    logger.debug("retrieve_species_id result:", result)
     return result

--- a/wqflask/db/webqtlDatabaseFunction.py
+++ b/wqflask/db/webqtlDatabaseFunction.py
@@ -22,11 +22,6 @@
 
 from db.call import fetch1
 
-###########################################################################
-# output: cursor instance
-# function: connect to database and return cursor instance
-###########################################################################
-
 
 def retrieve_species(group):
     """Get the species of a group (e.g. returns string "mouse" on "BXD"

--- a/wqflask/tests/unit/wqflask/api/test_gen_menu.py
+++ b/wqflask/tests/unit/wqflask/api/test_gen_menu.py
@@ -3,7 +3,6 @@ import unittest
 from unittest import mock
 
 from wqflask.api.gen_menu import gen_dropdown_json
-from wqflask.api.gen_menu import get_species
 from wqflask.api.gen_menu import get_groups
 from wqflask.api.gen_menu import get_types
 from wqflask.api.gen_menu import get_datasets
@@ -66,20 +65,6 @@ class TestGenMenu(unittest.TestCase):
                         ['M', 'M', 'Molecular Trait Datasets']]
             }
         }
-
-    def test_get_species(self):
-        """Test that assertion is raised when dataset and dataset_name
-        are defined"""
-        db_mock = mock.MagicMock()
-        with db_mock.cursor() as cursor:
-            cursor.fetchall.return_value = (
-                ('human', 'Human'),
-                ('mouse', 'Mouse'))
-            self.assertEqual(get_species(db_mock),
-                             [['human', 'Human'], ['mouse', 'Mouse']])
-            cursor.execute.assert_called_once_with(
-                "SELECT Name, MenuName FROM Species ORDER BY OrderId"
-            )
 
     def test_get_groups(self):
         """Test that species groups are grouped correctly"""
@@ -411,7 +396,7 @@ class TestGenMenu(unittest.TestCase):
     @mock.patch('wqflask.api.gen_menu.get_datasets')
     @mock.patch('wqflask.api.gen_menu.get_types')
     @mock.patch('wqflask.api.gen_menu.get_groups')
-    @mock.patch('wqflask.api.gen_menu.get_species')
+    @mock.patch('wqflask.api.gen_menu.get_all_species')
     def test_gen_dropdown_json(self,
                                species_mock,
                                groups_mock,

--- a/wqflask/wqflask/api/gen_menu.py
+++ b/wqflask/wqflask/api/gen_menu.py
@@ -1,28 +1,16 @@
+from gn3.db.species import get_all_species
 def gen_dropdown_json(conn):
     """Generates and outputs (as json file) the data for the main dropdown menus on
     the home page
     """
-
-    species = get_species(conn)
+    species = get_all_species(conn)
     groups = get_groups(species, conn)
     types = get_types(groups, conn)
     datasets = get_datasets(types, conn)
-
-    data = dict(species=species,
+    return dict(species=species,
                 groups=groups,
                 types=types,
                 datasets=datasets)
-
-    return data
-
-
-def get_species(conn):
-    """Build species list"""
-    with conn.cursor() as cursor:
-        cursor.execute("SELECT Name, MenuName FROM Species "
-                       "ORDER BY OrderId")
-        results = cursor.fetchall()
-        return [[name, menu_name] for name, menu_name in results]
 
 
 def get_groups(species, conn):

--- a/wqflask/wqflask/database.py
+++ b/wqflask/wqflask/database.py
@@ -14,9 +14,5 @@ db_session = scoped_session(sessionmaker(autocommit=False,
 Base = declarative_base()
 Base.query = db_session.query_property()
 
-
-def init_db():
-    Base.metadata.create_all(bind=engine)
-
-
-init_db()
+# Initialise the db
+Base.metadata.create_all(bind=engine)

--- a/wqflask/wqflask/decorators.py
+++ b/wqflask/wqflask/decorators.py
@@ -1,0 +1,14 @@
+"""This module contains gn2 decorators"""
+from flask import g
+from functools import wraps
+
+
+def admin_login_required(f):
+    """Use this for endpoints where admins are required"""
+    @wraps(f)
+    def wrap(*args, **kwargs):
+        if g.user_session.record.get(b"user_email_address") not in [
+                b"labwilliams@gmail.com"]:
+            return "You need to be admin", 401
+        return f(*args, **kwargs)
+    return wrap

--- a/wqflask/wqflask/templates/edit_trait.html
+++ b/wqflask/wqflask/templates/edit_trait.html
@@ -2,85 +2,100 @@
 {% block title %}Trait Submission{% endblock %}
 {% block content %}
 <!-- Start of body -->
-  <form method="post" action="/show_temp_trait">
-    <div class="container-fluid">
+Edit Trait for Published Database
+Submit Trait | Reset
 
-        {{ flash_me() }}
-
-        <div class="row" style="width: 1400px !important;">
-            <div class="col-xs-3">
-                <section id="description">
-                    <div>
-                        <h2 style="color: #5a5a5a;">Introduction</h2>
-                        <hr>
-                        <p>The trait values that you enter are statistically compared with verified genotypes collected at a set of microsatellite markers in each RI set. The markers are drawn from a set of over 750, but for each set redundant markers have been removed, preferentially retaining those that are most informative.</p>
-                        <p>These error-checked RI mapping data match theoretical expectations for RI strain sets. The cumulative adjusted length of the RI maps are approximately 1400 cM, a value that matches those of both MIT maps and Chromosome Committee Report maps. See our <a target="_blank" href="http://www.nervenet.org/papers/BXN.html">full description</a> of the genetic data collected as part of the WebQTL project.</p>
-                    </div>
-                </section>
-                <br>
-                <section id="description">
-                    <div>
-                        <h2 style="color: #5a5a5a;">About Your Data</h2>
-                        <hr>
-                        <p>You can open a separate window giving the number of strains for each data set and sample data.</p>
-                        <p>None of your submitted data is copied or stored by this system except during the actual processing of your submission. By the time the reply page displays in your browser, your submission has been cleared from this system.</p>
-                    </div>
-                </section>
-            </div>
-            <div style="padding-left:20px" class="col-xs-6" style="width: 600px !important;">
-                <section id="submission_form">
-                    <div class="form-group">
-                        <h2 style="color: #5a5a5a;">Edit Trait Form</h2>
-                        <hr>
-                        <div style="margin-bottom: 150px;" class="form-horizontal">
-                          <h3>Choose Dataset to Edit:</h3>
-                          <br>
-                          <div class="col-xs-10">
-                            <!-- Species -->
-                            <div class="form-group">
-                              <label for="species" class="col-xs-2 control-label">Species: </label>
-                              <div class="col-xs-4 controls">
-                                <select name="species" id="species" class="form-control span3" style="width: 280px !important;"></select>
-                              </div>
-                            </div>
-                            <!-- Group -->
-                            <div class="form-group">
-                              <label for="group" class="col-xs-2 control-label">Group: </label>
-                              <div class="col-xs-4 controls">
-                                <select name="group" id="group" class="form-control span3" style="width: 280px !important;"></select>
-                              </div>
-                            </div>
-                            <!-- Type -->
-                            <div class="form-group">
-                                <label for="group" class="col-xs-2 control-label">Type: </label>
-                                <div class="col-xs-4 controls">
-                                    <select name="type" id="type" class="form-control span3" style="width: 280px !important;"></select>
-                                </div>
-                            </div>
-                            <!-- Dataset -->
-                            <div class="form-group">
-                                <label for="group" class="col-xs-2 control-label">DataSet: </label>
-                                <div class="col-xs-4 controls">
-                                    <select name="dataset" id="dataset" class="form-control span3" style="width: 280px !important;"></select>
-                                </div>
-                            </div>
-                          </div>
-                          <div class="controls" style="display:block; margin-left: 40%; margin-right: 20%;">
-                              <input type="submit" style="width: 110px; margin-right: 25px;" class="btn btn-primary form-control col-xs-2" value="Submit Trait">
-                              <input type="reset" style="width: 110px;" class="btn btn-primary form-control col-xs-2" value="Reset">
-                          </div>
-                        </div>
-                </section>
-            </div>
+<form class="form-horizontal" method="post" action="/show_temp_trait">
+    <h2 class="text-center">Trait Information:</h2>
+    <div class="form-group">
+        <label for="pubmedId" class="col-sm-2 control-label">
+            Pubmed ID:
+        </label>
+        <!-- Do not enter PubMed_ID if this trait has not been Published.
+             If the PubMed_ID you entered is alreday stored in our
+             database, all the following fields except Post Publication
+             Description will be ignored.  Do not enter any non-digit
+             character in this field. -->
+        <div class="col-sm-10">
+            <textarea id="pubmedId" class="col-sm-10 form-control" rows="1"></textarea>
         </div>
     </div>
-  </form>
+    <div class="form-group">
+        <label for="prePubDesc" class="col-sm-2 control-label">Pre Publication Description:</label>
+        <div class="col-sm-10">
+            <textarea id="prePubDesc" class="form-control" rows="5"></textarea>
+        </div>
+        <!-- If the PubMed ID is entered, the Post Publication Description
+             will be shown to all users. If there is no PubMed ID, and the
+             Pre Publication Description is entered, only you and
+             authorized users can see the Post Publication Description -->
+    </div>
+    <div class="form-group">
+        <label for="owner" class="col-sm-2 control-label">Owner:</label>
+        <div class="col-sm-10">
+            <textarea id="owner" class="form-control" rows="1"></textarea>
+        </div>
+        <!-- Please provide detailed owner contact information including
+             full name, title, institution, address, email etc -->
+    </div>
+    <div class="form-group">
+        <label for="authors" class="col-sm-2 control-label">*Authors:</label>
+        <div class="col-sm-10">
+            <textarea id="authors" class="form-control" rows="2"></textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="title" class="col-sm-2 control-label">*Title:</label>
+        <div class="col-sm-10">
+            <textarea id="title" class="col-sm-10 form-control" rows="2"></textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="abstract" class="col-sm-2 control-label">Abstract:</label>
+        <div class="col-sm-10">
+            <textarea id="abstract" class="col-sm-10 form-control" rows="6"></textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="journal" class="col-sm-2 control-label">Journal:</label>
+        <div class="col-sm-10">
+            <textarea id="journal" class="col-sm-10 form-control" rows="1"></textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="pages" class="col-sm-2 control-label">Pages:</label>
+        <div class="col-sm-10">
+            <textarea id="pages" class="col-sm-10 form-control" rows="1"></textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="month" class="col-sm-2 control-label">Month:</label>
+        <div class="col-sm-10">
+            <textarea id="month" class="col-sm-10 form-control" rows="1"></textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="year" class="col-sm-2 control-label">*Year:</label>
+        <div class="col-sm-10">
+            <textarea id="year" class="col-sm-10 form-control" rows="6"></textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="units" class="col-sm-2 control-label">*Units:</label>
+        <div class="col-sm-10">
+            <textarea id="units" class="col-sm-10 form-control" rows="1"></textarea>
+        </div>
+        </div>
+    <!-- 
+         <h2 class="text-center">Trait Data:</h2>
+         Strain Name | Trait Data | SE | N Per Strain -->
+</form>
 
 {%endblock%}
 
-  {% block js %}
-  <script src="/static/new/javascript/dataset_select_menu_edit_trait.js"></script>
-    <script>
-      gn_server_url = "{{ gn_server_url }}";
-    </script>
+{% block js %}
+<script src="/static/new/javascript/dataset_select_menu_edit_trait.js"></script>
+<script>
+ gn_server_url = "{{ gn_server_url }}";
+</script>
 {% endblock %}

--- a/wqflask/wqflask/templates/edit_trait.html
+++ b/wqflask/wqflask/templates/edit_trait.html
@@ -148,6 +148,10 @@ Submit Trait | Reset
         </div>
     </div>
     <div class="controls" style="display:block; margin-left: 40%; margin-right: 20%;">
+        <input name="dataset-name" type="hidden" value="{{ publish_xref.id_ }}"/>
+        <input name="phenotype-id" type="hidden" value="{{ publish_xref.phenotype_id }}"/>
+        <input name="inbred-set-id" type="hidden" value="{{ publish_xref.inbred_set_id }}"/>
+        <input name="comments" type="hidden" value="{{ publish_xref.comments }}"/>
         <input type="submit" style="width: 125px; margin-right: 25px;" class="btn btn-primary form-control col-xs-2" value="Submit Change">
         <input type="reset" style="width: 110px;" class="btn btn-primary form-control col-xs-2" onClick="window.location.reload();" value="Reset">
     </div>

--- a/wqflask/wqflask/templates/edit_trait.html
+++ b/wqflask/wqflask/templates/edit_trait.html
@@ -12,27 +12,23 @@ Submit Trait | Reset
 
 {% endif %}
 
-<form class="form-horizontal" method="post" action="/show_temp_trait">
+<form id="edit-form" class="form-horizontal" method="post" action="/trait/update">
     <h2 class="text-center">Trait Information:</h2>
     <div class="form-group">
-        <label for="pubmedId" class="col-sm-2 control-label">Pubmed ID:</label>
+        <label for="pubmed-id" class="col-sm-2 control-label">Pubmed ID:</label>
         <!-- Do not enter PubMed_ID if this trait has not been Published.
              If the PubMed_ID you entered is alreday stored in our
              database, all the following fields except Post Publication
              Description will be ignored.  Do not enter any non-digit
              character in this field. -->
         <div class="col-sm-8">
-            <textarea id="pubmedId" class="form-control" rows="1">
-{{ publish_xref.publication_id |default('', true) }}
-            </textarea>
+            <textarea name="pubmed-id" class="form-control" rows="1">{{ publish_xref.publication_id |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
-        <label for="prePubDesc" class="col-sm-2 control-label">Pre Publication Description:</label>
+        <label for="pre-pub-desc" class="col-sm-2 control-label">Pre Publication Description:</label>
         <div class="col-sm-8">
-            <textarea id="prePubDesc" class="form-control" rows="4">
-{{ phenotype.pre_pub_description |default('', true) }}
-            </textarea>
+            <textarea name="pre-pub-desc" class="form-control" rows="4">{{ phenotype.pre_pub_description |default('', true) }}</textarea>
         </div>
         <!-- If the PubMed ID is entered, the Post Publication Description
              will be shown to all users. If there is no PubMed ID, and the
@@ -40,47 +36,37 @@ Submit Trait | Reset
              authorized users can see the Post Publication Description -->
     </div>
     <div class="form-group">
-        <label for="postPubDesc" class="col-sm-2 control-label">Post Publication Description:</label>
+        <label for="post-pub-desc" class="col-sm-2 control-label">Post Publication Description:</label>
         <div class="col-sm-8">
-            <textarea id="prePubDesc" class="form-control" rows="4">
-{{ phenotype.post_pub_description |default('', true) }}
-            </textarea>
+            <textarea name="pre-pub-desc" class="form-control" rows="4">{{ phenotype.post_pub_description |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
-        <label for="origDesc" class="col-sm-2 control-label">Original Description:</label>
+        <label for="orig-desc" class="col-sm-2 control-label">Original Description:</label>
         <div class="col-sm-8">
-            <textarea id="origDesc" class="form-control" rows="4">
-{{ phenotype.original_description |default('', true) }}
-            </textarea>
+            <textarea name="orig-desc" class="form-control" rows="4">{{ phenotype.original_description |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="units" class="col-sm-2 control-label">Units:</label>
         <div class="col-sm-8">
-            <textarea id="units" class="form-control" rows="1">
-{{ phenotype.units |default('', true) }}
-            </textarea>
+            <textarea name="units" class="form-control" rows="1">{{ phenotype.units |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
-        <label for="prePubAbbrev" class="col-sm-2 control-label">
+        <label for="pre-pub-abbrev" class="col-sm-2 control-label">
             Pre Publication Abbreviation:
         </label>
         <div class="col-sm-8">
-            <textarea id="prePubAbbrev" class="form-control" rows="1">
-{{ phenotype.pre_pub_abbreviation |default('', true) }}
-            </textarea>
+            <textarea name="pre-pub-abbrev" class="form-control" rows="1">{{ phenotype.pre_pub_abbreviation |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
-        <label for="postPubAbbrev" class="col-sm-2 control-label">
+        <label for="post-pub-abbrev" class="col-sm-2 control-label">
             Post Publication Abbreviation:
         </label>
         <div class="col-sm-8">
-            <textarea id="postPubAbbrev" class="form-control" rows="1">
-{{ phenotype.post_pub_abbreviation |default('', true) }}
-            </textarea>
+            <textarea name="post-pub-abbrev" class="form-control" rows="1">{{ phenotype.post_pub_abbreviation |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
@@ -88,27 +74,21 @@ Submit Trait | Reset
             Lab Code:
         </label>
         <div class="col-sm-8">
-            <textarea id="labcode" class="form-control" rows="1">
-{{ phenotype.lab_code |default('', true) }}
-            </textarea>
+            <textarea name="labcode" class="form-control" rows="1">{{ phenotype.lab_code |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
-        <label for="labcode" class="col-sm-2 control-label">
+        <label for="submitter" class="col-sm-2 control-label">
             Submitter:
         </label>
         <div class="col-sm-8">
-            <textarea id="submitter" class="form-control" rows="1">
-{{ phenotype.submitter |default('', true) }}
-            </textarea>
+            <textarea name="submitter" class="form-control" rows="1">{{ phenotype.submitter |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="owner" class="col-sm-2 control-label">Owner:</label>
         <div class="col-sm-8">
-            <textarea id="owner" class="form-control" rows="1">
-{{ phenotype.owner |default('', true) }}
-            </textarea>
+            <textarea name="owner" class="form-control" rows="1">{{ phenotype.owner |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
@@ -116,78 +96,60 @@ Submit Trait | Reset
             Authorized Users:
         </label>
         <div class="col-sm-8">
-            <textarea id="owner" class="form-control" rows="1">
-{{ phenotype.authorized_users |default('', true) }}
-            </textarea>
+            <textarea name="owner" class="form-control" rows="1">{{ phenotype.authorized_users |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="authors" class="col-sm-2 control-label">Authors:</label>
         <div class="col-sm-8">
-            <textarea id="authors" class="form-control" rows="2">
-{{ publication.authors |default('', true) }}
-            </textarea>
+            <textarea name="authors" class="form-control" rows="2">{{ publication.authors |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="title" class="col-sm-2 control-label">Title:</label>
         <div class="col-sm-8">
-            <textarea id="title" class="form-control" rows="2">
-{{ publication.title |default('', true) }}
-            </textarea>
+            <textarea name="title" class="form-control" rows="2">{{ publication.title |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="abstract" class="col-sm-2 control-label">Abstract:</label>
         <div class="col-sm-8">
-            <textarea id="abstract" class="form-control" rows="6">
-{{ publication.abstract |default('', true) }}
-            </textarea>
+            <textarea name="abstract" class="form-control" rows="6">{{ publication.abstract |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="journal" class="col-sm-2 control-label">Journal:</label>
         <div class="col-sm-8">
-            <textarea id="journal" class="form-control" rows="1">
-{{ publication.journal |default('', true) }}
-            </textarea>
+            <textarea name="journal" class="form-control" rows="1">{{ publication.journal |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="pages" class="col-sm-2 control-label">Pages:</label>
         <div class="col-sm-8">
-            <textarea id="pages" class="form-control" rows="1">
-{{ publication.pages |default('', true) }}
-            </textarea>
+            <textarea name="pages" class="form-control" rows="1">{{ publication.pages |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="month" class="col-sm-2 control-label">Month:</label>
         <div class="col-sm-8">
-            <textarea id="month" class="form-control" rows="1">
-{{ publication.month |default('', true) }}
-            </textarea>
+            <textarea name="month" class="form-control" rows="1">{{ publication.month |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="year" class="col-sm-2 control-label">Year:</label>
         <div class="col-sm-8">
-            <textarea id="year" class="form-control" rows="1">
-{{ publication.year |default('', true) }}
-            </textarea>
+            <textarea name="year" class="form-control" rows="1">{{ publication.year |default('', true) }}</textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="sequence" class="col-sm-2 control-label">Sequence:</label>
         <div class="col-sm-8">
-            <textarea id="sequence" class="form-control" rows="6">
-{{ publish_xref.sequence |default('', true) }}
-            </textarea>
+            <textarea name="sequence" class="form-control" rows="6">{{ publish_xref.sequence |default('', true) }}</textarea>
         </div>
     </div>
     <div class="controls" style="display:block; margin-left: 40%; margin-right: 20%;">
         <input type="submit" style="width: 125px; margin-right: 25px;" class="btn btn-primary form-control col-xs-2" value="Submit Change">
-        <input type="reset" style="width: 110px;" class="btn btn-primary form-control col-xs-2" value="Reset">
+        <input type="reset" style="width: 110px;" class="btn btn-primary form-control col-xs-2" onClick="window.location.reload();" value="Reset">
     </div>
 </form>
 

--- a/wqflask/wqflask/templates/edit_trait.html
+++ b/wqflask/wqflask/templates/edit_trait.html
@@ -5,25 +5,34 @@
 Edit Trait for Published Database
 Submit Trait | Reset
 
+{% if publish_xref.comments %}
+<h2>Update History:</h2>
+
+{{ publish_xref.comments }}
+
+{% endif %}
+
 <form class="form-horizontal" method="post" action="/show_temp_trait">
     <h2 class="text-center">Trait Information:</h2>
     <div class="form-group">
-        <label for="pubmedId" class="col-sm-2 control-label">
-            Pubmed ID:
-        </label>
+        <label for="pubmedId" class="col-sm-2 control-label">Pubmed ID:</label>
         <!-- Do not enter PubMed_ID if this trait has not been Published.
              If the PubMed_ID you entered is alreday stored in our
              database, all the following fields except Post Publication
              Description will be ignored.  Do not enter any non-digit
              character in this field. -->
-        <div class="col-sm-10">
-            <textarea id="pubmedId" class="col-sm-10 form-control" rows="1"></textarea>
+        <div class="col-sm-8">
+            <textarea id="pubmedId" class="form-control" rows="1">
+{{ publish_xref.publication_id |default('', true) }}
+            </textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="prePubDesc" class="col-sm-2 control-label">Pre Publication Description:</label>
-        <div class="col-sm-10">
-            <textarea id="prePubDesc" class="form-control" rows="5"></textarea>
+        <div class="col-sm-8">
+            <textarea id="prePubDesc" class="form-control" rows="4">
+{{ phenotype.pre_pub_description |default('', true) }}
+            </textarea>
         </div>
         <!-- If the PubMed ID is entered, the Post Publication Description
              will be shown to all users. If there is no PubMed ID, and the
@@ -31,70 +40,160 @@ Submit Trait | Reset
              authorized users can see the Post Publication Description -->
     </div>
     <div class="form-group">
+        <label for="postPubDesc" class="col-sm-2 control-label">Post Publication Description:</label>
+        <div class="col-sm-8">
+            <textarea id="prePubDesc" class="form-control" rows="4">
+{{ phenotype.post_pub_description |default('', true) }}
+            </textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="origDesc" class="col-sm-2 control-label">Original Description:</label>
+        <div class="col-sm-8">
+            <textarea id="origDesc" class="form-control" rows="4">
+{{ phenotype.original_description |default('', true) }}
+            </textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="units" class="col-sm-2 control-label">Units:</label>
+        <div class="col-sm-8">
+            <textarea id="units" class="form-control" rows="1">
+{{ phenotype.units |default('', true) }}
+            </textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="prePubAbbrev" class="col-sm-2 control-label">
+            Pre Publication Abbreviation:
+        </label>
+        <div class="col-sm-8">
+            <textarea id="prePubAbbrev" class="form-control" rows="1">
+{{ phenotype.pre_pub_abbreviation |default('', true) }}
+            </textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="postPubAbbrev" class="col-sm-2 control-label">
+            Post Publication Abbreviation:
+        </label>
+        <div class="col-sm-8">
+            <textarea id="postPubAbbrev" class="form-control" rows="1">
+{{ phenotype.post_pub_abbreviation |default('', true) }}
+            </textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="labcode" class="col-sm-2 control-label">
+            Lab Code:
+        </label>
+        <div class="col-sm-8">
+            <textarea id="labcode" class="form-control" rows="1">
+{{ phenotype.lab_code |default('', true) }}
+            </textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="labcode" class="col-sm-2 control-label">
+            Submitter:
+        </label>
+        <div class="col-sm-8">
+            <textarea id="submitter" class="form-control" rows="1">
+{{ phenotype.submitter |default('', true) }}
+            </textarea>
+        </div>
+    </div>
+    <div class="form-group">
         <label for="owner" class="col-sm-2 control-label">Owner:</label>
-        <div class="col-sm-10">
-            <textarea id="owner" class="form-control" rows="1"></textarea>
-        </div>
-        <!-- Please provide detailed owner contact information including
-             full name, title, institution, address, email etc -->
-    </div>
-    <div class="form-group">
-        <label for="authors" class="col-sm-2 control-label">*Authors:</label>
-        <div class="col-sm-10">
-            <textarea id="authors" class="form-control" rows="2"></textarea>
+        <div class="col-sm-8">
+            <textarea id="owner" class="form-control" rows="1">
+{{ phenotype.owner |default('', true) }}
+            </textarea>
         </div>
     </div>
     <div class="form-group">
-        <label for="title" class="col-sm-2 control-label">*Title:</label>
-        <div class="col-sm-10">
-            <textarea id="title" class="col-sm-10 form-control" rows="2"></textarea>
+        <label for="owner" class="col-sm-2 control-label">
+            Authorized Users:
+        </label>
+        <div class="col-sm-8">
+            <textarea id="owner" class="form-control" rows="1">
+{{ phenotype.authorized_users |default('', true) }}
+            </textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="authors" class="col-sm-2 control-label">Authors:</label>
+        <div class="col-sm-8">
+            <textarea id="authors" class="form-control" rows="2">
+{{ publication.authors |default('', true) }}
+            </textarea>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="title" class="col-sm-2 control-label">Title:</label>
+        <div class="col-sm-8">
+            <textarea id="title" class="form-control" rows="2">
+{{ publication.title |default('', true) }}
+            </textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="abstract" class="col-sm-2 control-label">Abstract:</label>
-        <div class="col-sm-10">
-            <textarea id="abstract" class="col-sm-10 form-control" rows="6"></textarea>
+        <div class="col-sm-8">
+            <textarea id="abstract" class="form-control" rows="6">
+{{ publication.abstract |default('', true) }}
+            </textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="journal" class="col-sm-2 control-label">Journal:</label>
-        <div class="col-sm-10">
-            <textarea id="journal" class="col-sm-10 form-control" rows="1"></textarea>
+        <div class="col-sm-8">
+            <textarea id="journal" class="form-control" rows="1">
+{{ publication.journal |default('', true) }}
+            </textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="pages" class="col-sm-2 control-label">Pages:</label>
-        <div class="col-sm-10">
-            <textarea id="pages" class="col-sm-10 form-control" rows="1"></textarea>
+        <div class="col-sm-8">
+            <textarea id="pages" class="form-control" rows="1">
+{{ publication.pages |default('', true) }}
+            </textarea>
         </div>
     </div>
     <div class="form-group">
         <label for="month" class="col-sm-2 control-label">Month:</label>
-        <div class="col-sm-10">
-            <textarea id="month" class="col-sm-10 form-control" rows="1"></textarea>
+        <div class="col-sm-8">
+            <textarea id="month" class="form-control" rows="1">
+{{ publication.month |default('', true) }}
+            </textarea>
         </div>
     </div>
     <div class="form-group">
-        <label for="year" class="col-sm-2 control-label">*Year:</label>
-        <div class="col-sm-10">
-            <textarea id="year" class="col-sm-10 form-control" rows="6"></textarea>
+        <label for="year" class="col-sm-2 control-label">Year:</label>
+        <div class="col-sm-8">
+            <textarea id="year" class="form-control" rows="1">
+{{ publication.year |default('', true) }}
+            </textarea>
         </div>
     </div>
     <div class="form-group">
-        <label for="units" class="col-sm-2 control-label">*Units:</label>
-        <div class="col-sm-10">
-            <textarea id="units" class="col-sm-10 form-control" rows="1"></textarea>
+        <label for="sequence" class="col-sm-2 control-label">Sequence:</label>
+        <div class="col-sm-8">
+            <textarea id="sequence" class="form-control" rows="6">
+{{ publish_xref.sequence |default('', true) }}
+            </textarea>
         </div>
-        </div>
-    <!-- 
-         <h2 class="text-center">Trait Data:</h2>
-         Strain Name | Trait Data | SE | N Per Strain -->
+    </div>
+    <div class="controls" style="display:block; margin-left: 40%; margin-right: 20%;">
+        <input type="submit" style="width: 125px; margin-right: 25px;" class="btn btn-primary form-control col-xs-2" value="Submit Change">
+        <input type="reset" style="width: 110px;" class="btn btn-primary form-control col-xs-2" value="Reset">
+    </div>
 </form>
 
 {%endblock%}
 
 {% block js %}
-<script src="/static/new/javascript/dataset_select_menu_edit_trait.js"></script>
 <script>
  gn_server_url = "{{ gn_server_url }}";
 </script>

--- a/wqflask/wqflask/templates/show_trait_details.html
+++ b/wqflask/wqflask/templates/show_trait_details.html
@@ -235,7 +235,7 @@
         {% endif %}
         <button type="button" id="view_in_gn1" class="btn btn-primary" title="View Trait in GN1" onclick="window.open('http://gn1.genenetwork.org/webqtl/main.py?cmd=show&db={{ this_trait.dataset.name }}&probeset={{ this_trait.name }}', '_blank')">Go to GN1</button>
         {% if admin_status == "owner" or admin_status == "edit-admins" or admin_status == "edit-access" %}
-            <button type="button" id="edit_resource" class="btn btn-success" title="Edit Resource" onclick="window.open('./resources/manage?resource_id={{ resource_id }}', '_blank')">Edit</button>
+        <button type="button" id="edit_resource" class="btn btn-success" title="Edit Resource" onclick="window.open('/trait/{{ this_trait.name }}/edit/{{ this_trait.dataset.id }}', '_blank')">Edit</button>
         {% endif %}
     </div>
 </div>

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -416,7 +416,7 @@ def submit_trait_form():
 
 
 @app.route("/trait/<name>/edit/<inbred_set_id>")
-def show_edit_trait_page(name, inbred_set_id):
+def edit_trait(name, inbred_set_id):
     from gn3.db.phenotypes import (Phenotype,
                                    PublishXRef,
                                    Publication,

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -461,36 +461,47 @@ def update_trait():
     data_ = {k: v for k, v in request.form.items() if v is not ''}
 
     # Run updates:
-    update(conn, "Phenotype",
-           data=Phenotype(
-               pre_pub_description=data_.get("pre-pub-desc"),
-               post_pub_description=data_.get("post-pub-desc"),
-               original_description=data_.get("orig-desc"),
-               units=data_.get("units"),
-               pre_pub_abbreviation=data_.get("pre-pub-abbrev"),
-               post_pub_abbreviation=data_.get("post-pub-abbrev"),
-               lab_code=data_.get("labcode"),
-               submitter=data_.get("submitter"),
-               owner=data_.get("owner"),
-           ),
-           where=Phenotype(id_=data_.get("phenotype-id")))
-    update(conn, "Publication",
-           data=Publication(
-               abstract=data_.get("abstract"),
-               authors=data_.get("authors"),
-               title=data_.get("title"),
-               journal=data_.get("journal"),
-               volume=data_.get("volume"),
-               pages=data_.get("pages"),
-               month=data_.get("month"),
-               year=data_.get("year")),
-           where=Publication(id_=data_.get("pubmed-id")))
-    update(conn, "PublishXRef",
-           data=PublishXRef(comments="",
-                            publication_id=data_.get("pubmed-id")),
-           where=PublishXRef(
-               id_=data_.get("dataset-name"),
-               inbred_set_id=data_.get("inbred-set-id")))
+    updated_phenotypes = update(
+        conn, "Phenotype",
+        data=Phenotype(
+            pre_pub_description=data_.get("pre-pub-desc"),
+            post_pub_description=data_.get("post-pub-desc"),
+            original_description=data_.get("orig-desc"),
+            units=data_.get("units"),
+            pre_pub_abbreviation=data_.get("pre-pub-abbrev"),
+            post_pub_abbreviation=data_.get("post-pub-abbrev"),
+            lab_code=data_.get("labcode"),
+            submitter=data_.get("submitter"),
+            owner=data_.get("owner"),
+        ),
+        where=Phenotype(id_=data_.get("phenotype-id")))
+    updated_publications = update(
+        conn, "Publication",
+        data=Publication(
+            abstract=data_.get("abstract"),
+            authors=data_.get("authors"),
+            title=data_.get("title"),
+            journal=data_.get("journal"),
+            volume=data_.get("volume"),
+            pages=data_.get("pages"),
+            month=data_.get("month"),
+            year=data_.get("year")),
+        where=Publication(id_=data_.get("pubmed-id")))
+    if updated_phenotypes or updated_publications:
+        comments = data_.get("comments")
+        if comments:
+            comments = (f"{comments}\r\n"
+                        f"{g.user_session.record.get(b'user_name')}")
+        update(conn, "PublishXRef",
+               data=PublishXRef(
+                   comments=(f"{data_.get('comments')}\r\n"
+                             "Modified by: "
+                             f"{g.user_session.record.get(b'user_name').decode('utf-8')} "
+                             f"on {str(datetime.datetime.now())}"),
+                   publication_id=data_.get("pubmed-id")),
+               where=PublishXRef(
+                   id_=data_.get("dataset-name"),
+                   inbred_set_id=data_.get("inbred-set-id")))
     return redirect("/trait/10007/edit/1")
 
 

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -39,10 +39,8 @@ from flask import redirect
 from flask import url_for
 from flask import send_file
 
-from wqflask import collect
 from wqflask import search_results
 from wqflask import server_side
-from wqflask.submit_bnw import get_bnw_input
 from base.data_set import create_dataset  # Used by YAML in marker_regression
 from wqflask.show_trait import show_trait
 from wqflask.show_trait import export_trait_data

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -65,6 +65,7 @@ from wqflask.export_traits import export_search_results_csv
 from wqflask.gsearch import GSearch
 from wqflask.update_search_results import GSearch as UpdateGSearch
 from wqflask.docs import Docs, update_text
+from wqflask.decorators import admin_login_required
 from wqflask.db_info import InfoPage
 
 from utility import temp_data
@@ -422,6 +423,7 @@ def submit_trait_form():
 
 
 @app.route("/trait/<name>/edit/<inbred_set_id>")
+@admin_login_required
 def edit_trait(name, inbred_set_id):
     conn = MySQLdb.Connect(db=current_app.config.get("DB_NAME"),
                            user=current_app.config.get("DB_USER"),

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -23,11 +23,12 @@ import array
 import sqlalchemy
 from wqflask import app
 
+from gn3.db import fetchone
+from gn3.db import update
 from gn3.db.phenotypes import Phenotype
 from gn3.db.phenotypes import PublishXRef
 from gn3.db.phenotypes import Publication
-from gn3.db.phenotypes import fetchone
-from gn3.db.phenotypes import update
+
 
 from flask import current_app
 from flask import g

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -9,6 +9,7 @@ import csv
 import simplejson as json
 import xlsxwriter
 import io  # Todo: Use cStringIO?
+import MySQLdb
 
 from zipfile import ZipFile, ZIP_DEFLATED
 
@@ -21,6 +22,12 @@ import base64
 import array
 import sqlalchemy
 from wqflask import app
+
+from gn3.db.phenotypes import Phenotype
+from gn3.db.phenotypes import PublishXRef
+from gn3.db.phenotypes import Publication
+from gn3.db.phenotypes import fetchone
+
 from flask import current_app
 from flask import g
 from flask import Response
@@ -417,11 +424,6 @@ def submit_trait_form():
 
 @app.route("/trait/<name>/edit/<inbred_set_id>")
 def edit_trait(name, inbred_set_id):
-    from gn3.db.phenotypes import (Phenotype,
-                                   PublishXRef,
-                                   Publication,
-                                   fetchone)
-    import MySQLdb
     conn = MySQLdb.Connect(db=current_app.config.get("DB_NAME"),
                            user=current_app.config.get("DB_USER"),
                            passwd=current_app.config.get("DB_PASS"),


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->
This PR:
- Remove logger info from [webqtlDatabaseFunction](https://github.com/genenetwork/genenetwork2/pull/571/commits/002108e14f3d3823c43d7faebaf6f1f8b3c7a3df)
- Replaces `get_species` with `get_all_species` from gn3
- Adds edit trait capability(you can't edit individual traits now)
- Adds an login decorator
- Updates the docker image to point to: [genenetwork2](https://hub.docker.com/repository/docker/bonfacekilz/genenetwork2)

#### How should this be tested?
<!-- What should you do to test this PR? Is there any manual quality
assurance checks that should be done. What are the expectations -->
- All tests should pass
- @robwwilliams on any trait page, you should be able to see the `Edit` button. Clicking that takes you to the edit page(only @robwwilliams has access to this page).

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->
Most of that work is done. Improvements that'll be added later:
- Storing a diff of edits.
- Thinking out redirects for pages not accessible to users: Now I simply just show a message: `return "You need to be admin", 401`

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->
N/A

#### Screenshots (if appropriate)
Edit button:
![image](https://user-images.githubusercontent.com/11820306/119638312-32c58080-be1f-11eb-96fa-114ee4937d67.png)

Edit page:
![image](https://user-images.githubusercontent.com/11820306/119639006-ddd63a00-be1f-11eb-9ee6-1c7b7afde5dc.png)


#### Questions
<!-- Are there any questions for the reviewer -->
N/A