### PR TITLE
Feature/add scroller to mapping results

### DIFF
--- a/wqflask/wqflask/marker_regression/run_mapping.py
+++ b/wqflask/wqflask/marker_regression/run_mapping.py
@@ -673,9 +673,9 @@ def trim_markers_for_table(markers):
         sorted_markers = sorted(
             markers, key=lambda k: k['lrs_value'], reverse=True)
 
-    # ZS: So we end up with a list of just 2000 markers
-    if len(sorted_markers) >= 2000:
-        trimmed_sorted_markers = sorted_markers[:2000]
+    #ZS: So we end up with a list of just 2000 markers
+    if len(sorted_markers) >= 10000:
+        trimmed_sorted_markers = sorted_markers[:10000]
         return trimmed_sorted_markers
     else:
         return sorted_markers

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -357,7 +357,9 @@
     {% endif %}
 
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
-   <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/buttons/js/dataTables.buttons.min.js') }}"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/buttons/js/dataTables.buttons.min.js') }}"></script>
+    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/scroller/js/dataTables.scroller.min.js') }}"></script>
+
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/scientific.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTablesExtensions/plugins/sorting/natural.js') }}"></script>
     <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='purescript-genome-browser/js/purescript-genetics-browser.js') }}"></script>
@@ -409,13 +411,12 @@
                   "info": "Showing from _START_ to _END_ of " + js_data.total_markers + " records",
                 },
                 "order": [[1, "asc" ]],
-                "sDom": "iRZtir",
-                "iDisplayLength": -1,
-                "autoWidth": false,
-                "deferRender": true,
+                "sDom": "itir",
+                "autoWidth": true,
                 "bSortClasses": false,
-                "scrollCollapse": false,
-                "paging": false
+                "scrollY": "100vh",
+                "scroller":  true,
+                "scrollCollapse": true
             } );
             {% elif selectedChr != -1 and plotScale =="physic" and (dataset.group.species == 'mouse' or dataset.group.species == 'rat') %}
             $('#trait_table').dataTable( {


### PR DESCRIPTION
#### Description
This adds Scroller functionality to the mapping results table and increases the number of displayed results to 10000

#### How should this be tested?
Do mapping and check that the results table works as expected

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
