### PR TITLE
Feature/add filter by study samples

### DIFF
--- a/wqflask/base/data_set.py
+++ b/wqflask/base/data_set.py
@@ -398,6 +398,15 @@ class DatasetGroup:
         if maternal and paternal:
             self.parlist = [maternal, paternal]
 
+    def get_study_samplelists(self):
+        study_sample_file = "%s/study_sample_lists/%s.json" % (webqtlConfig.GENODIR, self.name)
+        try:
+            f = open(study_sample_file)
+        except:
+            return None
+        study_samples = json.load(f)
+        return study_samples
+
     def get_genofiles(self):
         jsonfile = "%s/%s.json" % (webqtlConfig.GENODIR, self.name)
         try:

--- a/wqflask/base/data_set.py
+++ b/wqflask/base/data_set.py
@@ -399,7 +399,7 @@ class DatasetGroup:
             self.parlist = [maternal, paternal]
 
     def get_study_samplelists(self):
-        study_sample_file = "%s/study_sample_lists/%s.json" % (webqtlConfig.GENODIR, self.name)
+        study_sample_file = locate_ignore_error(self.name + ".json", 'study_sample_lists')
         try:
             f = open(study_sample_file)
         except:

--- a/wqflask/base/data_set.py
+++ b/wqflask/base/data_set.py
@@ -403,7 +403,7 @@ class DatasetGroup:
         try:
             f = open(study_sample_file)
         except:
-            return None
+            return []
         study_samples = json.load(f)
         return study_samples
 

--- a/wqflask/wqflask/show_trait/show_trait.py
+++ b/wqflask/wqflask/show_trait/show_trait.py
@@ -192,6 +192,7 @@ class ShowTrait:
                 [self.dataset.species.chromosomes.chromosomes[this_chr].name, i])
 
         self.genofiles = self.dataset.group.get_genofiles()
+        self.study_samplelists = self.dataset.group.get_study_samplelists()
 
         # ZS: No need to grab scales from .geno file unless it's using
         # a mapping method that reads .geno files

--- a/wqflask/wqflask/show_trait/show_trait.py
+++ b/wqflask/wqflask/show_trait/show_trait.py
@@ -192,7 +192,8 @@ class ShowTrait:
                 [self.dataset.species.chromosomes.chromosomes[this_chr].name, i])
 
         self.genofiles = self.dataset.group.get_genofiles()
-        self.study_samplelists = self.dataset.group.get_study_samplelists()
+        study_samplelist_json = self.dataset.group.get_study_samplelists()
+        self.study_samplelists = [study["title"] for study in study_samplelist_json]
 
         # ZS: No need to grab scales from .geno file unless it's using
         # a mapping method that reads .geno files
@@ -281,6 +282,7 @@ class ShowTrait:
         hddn['selected_chr'] = -1
         hddn['mapping_display_all'] = True
         hddn['suggestive'] = 0
+        hddn['study_samplelists'] = json.dumps(study_samplelist_json)
         hddn['num_perm'] = 0
         hddn['categorical_vars'] = ""
         if categorical_var_list:

--- a/wqflask/wqflask/static/new/javascript/show_trait.js
+++ b/wqflask/wqflask/static/new/javascript/show_trait.js
@@ -713,9 +713,23 @@ block_by_index = function() {
   for (_k = 0, _len1 = index_list.length; _k < _len1; _k++) {
     index = index_list[_k];
     val_nodes[index - 1].childNodes[0].value = "x";
-
   }
 };
+
+filter_by_study = function() {
+  let this_study = $('#filter_study').val();
+  let block_group = $('#filter_study_group').val();
+  let study_sample_data = JSON.parse($('input[name=study_samplelists]').val())
+  let filter_samples = study_sample_data[parseInt(this_study)]['samples']
+  let sample_nodes = table_api.column(2).nodes().to$();
+  let val_nodes = table_api.column(3).nodes().to$();
+  for (i = 0; i < sample_nodes.length; i++) {
+    this_sample = sample_nodes[i].childNodes[0].innerText;
+    if (!filter_samples.includes(this_sample)){
+      val_nodes[i].childNodes[0].value = "x";
+    }
+  }
+}
 
 filter_by_value = function() {
   let filter_logic = $('#filter_logic').val();
@@ -1689,6 +1703,11 @@ $('#block_by_index').click(function(){
   block_by_index();
   edit_data_change();
 });
+
+$('#filter_by_study').click(function(){
+  filter_by_study();
+  edit_data_change();
+})
 
 $('#filter_by_value').click(function(){
   filter_by_value();

--- a/wqflask/wqflask/static/new/javascript/show_trait.js
+++ b/wqflask/wqflask/static/new/javascript/show_trait.js
@@ -718,9 +718,19 @@ block_by_index = function() {
 
 filter_by_study = function() {
   let this_study = $('#filter_study').val();
-  let block_group = $('#filter_study_group').val();
+
   let study_sample_data = JSON.parse($('input[name=study_samplelists]').val())
   let filter_samples = study_sample_data[parseInt(this_study)]['samples']
+
+  if ($('#filter_study_group').length){
+    let block_group = $('#filter_study_group').val();
+    if (block_group === "other") {
+      table_api = $('#samples_other').DataTable();
+    } else {
+      table_api = $('#samples_primary').DataTable();
+    }
+  }
+
   let sample_nodes = table_api.column(2).nodes().to$();
   let val_nodes = table_api.column(3).nodes().to$();
   for (i = 0; i < sample_nodes.length; i++) {

--- a/wqflask/wqflask/templates/show_trait_transform_and_filter.html
+++ b/wqflask/wqflask/templates/show_trait_transform_and_filter.html
@@ -45,6 +45,25 @@
         <input type="button" id="exclude_by_attr" class="btn btn-danger" value="Block">
     </div>
     {% endif %}
+    {% if study_samplelists|length > 0 %}
+    <div id="filterMenuSpan" class="input-append block-div-2">
+      <label for="filter_study_select">Filter samples by study: </label>
+      <select id="filter_study">
+        {% for study in study_samplelists %}
+        <option value="{{ loop.index + 1 }}">{{ study }}</option>
+        {% endfor %}
+      </select>
+      <select id="filter_study_group" size="1">
+        <option value="primary">
+          {{ sample_group_types['samples_primary'] }}
+        </option>
+        <option value="other">
+          {{ sample_group_types['samples_other'] }}
+        </option>
+      </select>
+      <input type="button" id="filter_by_study" class="btn btn-danger" value="Filter">
+    </div>
+    {% endif %}
     <div id="filterMenuSpan" class="input-append block-div-2">
       <label for="filter_samples_field">Filter samples by {% if (numerical_var_list|length == 0) and (not js_data.se_exists) %}value{% endif %} </label>
       {% if (numerical_var_list|length > 0) or js_data.se_exists %}

--- a/wqflask/wqflask/templates/show_trait_transform_and_filter.html
+++ b/wqflask/wqflask/templates/show_trait_transform_and_filter.html
@@ -50,9 +50,10 @@
       <label for="filter_study_select">Filter samples by study: </label>
       <select id="filter_study">
         {% for study in study_samplelists %}
-        <option value="{{ loop.index + 1 }}">{{ study }}</option>
+        <option value="{{ loop.index - 1 }}">{{ study }}</option>
         {% endfor %}
       </select>
+      {% if sample_groups|length != 1 %}
       <select id="filter_study_group" size="1">
         <option value="primary">
           {{ sample_group_types['samples_primary'] }}
@@ -61,6 +62,7 @@
           {{ sample_group_types['samples_other'] }}
         </option>
       </select>
+      {% endif %}
       <input type="button" id="filter_by_study" class="btn btn-danger" value="Filter">
     </div>
     {% endif %}


### PR DESCRIPTION
#### Description
This adds a feature that lets users filter samples by the study those samples are a part of. Currently this is only used with the BXD-Longevity group. It uses a JSON file that contains a list of studies and their corresponding sample lists.

#### How should this be tested?
Load any BXD-Longevity trait (like https://genenetwork.org/show_trait?trait_id=10005&dataset=BXD-LongevityPublish ), click the "Transform and Filter Data" tab, and there should be an option "Filter samples by study." Choosing a study and clicking "Filter" should cause all samples that are not a part of that study to be X'd out.

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
