### PR TITLE
Feature/add more mapping metadata

### DIFF
--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -1249,18 +1249,18 @@ class DisplayMappingResults:
 
             if self.this_trait.symbol:
                 identification += "Trait: %s - %s" % (
-                    self.this_trait.name, self.this_trait.symbol)
+                    self.this_trait.display_name, self.this_trait.symbol)
             elif self.dataset.type == "Publish":
                 if self.this_trait.post_publication_abbreviation:
                     identification += "Trait: %s - %s" % (
-                        self.this_trait.name, self.this_trait.post_publication_abbreviation)
+                        self.this_trait.display_name, self.this_trait.post_publication_abbreviation)
                 elif self.this_trait.pre_publication_abbreviation:
                     identification += "Trait: %s - %s" % (
-                        self.this_trait.name, self.this_trait.pre_publication_abbreviation)
+                        self.this_trait.display_name, self.this_trait.pre_publication_abbreviation)
                 else:
-                    identification += "Trait: %s" % (self.this_trait.name)
+                    identification += "Trait: %s" % (self.this_trait.display_name)
             else:
-                identification += "Trait: %s" % (self.this_trait.name)
+                identification += "Trait: %s" % (self.this_trait.display_name)
             identification += " with %s samples" % (self.n_samples)
 
             d = 4 + max(

--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -24,6 +24,7 @@
 #
 # Last updated by Zach 12/14/2010
 
+import datetime
 import string
 from math import *
 from PIL import Image
@@ -271,6 +272,7 @@ class DisplayMappingResults:
         # Needing for form submission when doing single chr
         # mapping or remapping after changing options
         self.sample_vals = start_vars['sample_vals']
+        self.vals_hash= start_vars['vals_hash']
         self.sample_vals_dict = json.loads(self.sample_vals)
 
         self.transform = start_vars['transform']
@@ -651,7 +653,7 @@ class DisplayMappingResults:
             btminfo.append(
                 'Mapping using genotype data as a trait will result in infinity LRS at one locus. In order to display the result properly, all LRSs higher than 100 are capped at 100.')
 
-    def plotIntMapping(self, canvas, offset=(80, 120, 90, 100), zoom=1, startMb=None, endMb=None, showLocusForm=""):
+    def plotIntMapping(self, canvas, offset=(80, 120, 110, 100), zoom=1, startMb=None, endMb=None, showLocusForm=""):
         im_drawer = ImageDraw.Draw(canvas)
         # calculating margins
         xLeftOffset, xRightOffset, yTopOffset, yBottomOffset = offset
@@ -661,7 +663,7 @@ class DisplayMappingResults:
             if self.legendChecked:
                 yTopOffset += 10
                 if self.covariates != "" and self.controlLocus and self.doControl != "false":
-                    yTopOffset += 20
+                    yTopOffset += 25
                 if len(self.transform) > 0:
                     yTopOffset += 5
             else:
@@ -1195,43 +1197,47 @@ class DisplayMappingResults:
             dataset_label = "%s - %s" % (self.dataset.group.name,
                                          self.dataset.fullname)
 
-        string1 = 'Dataset: %s' % (dataset_label)
+
+        current_datetime = datetime.datetime.now()
+        string1 = 'UTC Timestamp: %s' % (current_datetime.strftime("%b %d %Y %H:%M:%S"))
+        string2 = 'Dataset: %s' % (dataset_label)
+        string3 = 'Trait Hash: %s' % (self.vals_hash)
 
         if self.genofile_string == "":
-            string2 = 'Genotype File: %s.geno' % self.dataset.group.name
+            string4 = 'Genotype File: %s.geno' % self.dataset.group.name
         else:
-            string2 = 'Genotype File: %s' % self.genofile_string
+            string4 = 'Genotype File: %s' % self.genofile_string
 
-        string4 = ''
+        string6 = ''
         if self.mapping_method == "gemma" or self.mapping_method == "gemma_bimbam":
             if self.use_loco == "True":
-                string3 = 'Using GEMMA mapping method with LOCO and '
+                string5 = 'Using GEMMA mapping method with LOCO and '
             else:
-                string3 = 'Using GEMMA mapping method with '
+                string5 = 'Using GEMMA mapping method with '
             if self.covariates != "":
-                string3 += 'the cofactors below:'
+                string5 += 'the cofactors below:'
                 cofactor_names = ", ".join(
                     [covar.split(":")[0] for covar in self.covariates.split(",")])
-                string4 = cofactor_names
+                string6 = cofactor_names
             else:
-                string3 += 'no cofactors'
+                string5 += 'no cofactors'
         elif self.mapping_method == "rqtl_plink" or self.mapping_method == "rqtl_geno":
-            string3 = 'Using R/qtl mapping method with '
+            string5 = 'Using R/qtl mapping method with '
             if self.covariates != "":
-                string3 += 'the cofactors below:'
+                string5 += 'the cofactors below:'
                 cofactor_names = ", ".join(
                     [covar.split(":")[0] for covar in self.covariates.split(",")])
-                string4 = cofactor_names
+                string6 = cofactor_names
             elif self.controlLocus and self.doControl != "false":
-                string3 += '%s as control' % self.controlLocus
+                string5 += '%s as control' % self.controlLocus
             else:
-                string3 += 'no cofactors'
+                string5 += 'no cofactors'
         else:
-            string3 = 'Using Haldane mapping function with '
+            string5 = 'Using Haldane mapping function with '
             if self.controlLocus and self.doControl != "false":
-                string3 += '%s as control' % self.controlLocus
+                string5 += '%s as control' % self.controlLocus
             else:
-                string3 += 'no control for other QTLs'
+                string5 += 'no control for other QTLs'
 
         y_constant = 10
         if self.this_trait.name:
@@ -1260,7 +1266,9 @@ class DisplayMappingResults:
             d = 4 + max(
                 im_drawer.textsize(identification, font=labelFont)[0],
                 im_drawer.textsize(string1, font=labelFont)[0],
-                im_drawer.textsize(string2, font=labelFont)[0])
+                im_drawer.textsize(string2, font=labelFont)[0],
+                im_drawer.textsize(string3, font=labelFont)[0],
+                im_drawer.textsize(string4, font=labelFont)[0])
             im_drawer.text(
                 text=identification,
                 xy=(xLeftOffset, y_constant * fontZoom), font=labelFont,
@@ -1269,7 +1277,9 @@ class DisplayMappingResults:
         else:
             d = 4 + max(
                 im_drawer.textsize(string1, font=labelFont)[0],
-                im_drawer.textsize(string2, font=labelFont)[0])
+                im_drawer.textsize(string2, font=labelFont)[0],
+                im_drawer.textsize(string3, font=labelFont)[0],
+                im_drawer.textsize(string4, font=labelFont)[0])
 
         if len(self.transform) > 0:
             transform_text = "Transform - "
@@ -1296,14 +1306,22 @@ class DisplayMappingResults:
             text=string2, xy=(xLeftOffset, y_constant * fontZoom),
             font=labelFont, fill=labelColor)
         y_constant += 15
-        if string3 != '':
+        im_drawer.text(
+            text=string3, xy=(xLeftOffset, y_constant * fontZoom),
+            font=labelFont, fill=labelColor)
+        y_constant += 15
+        im_drawer.text(
+            text=string4, xy=(xLeftOffset, y_constant * fontZoom),
+            font=labelFont, fill=labelColor)
+        y_constant += 15
+        if string4 != '':
             im_drawer.text(
-                text=string3, xy=(xLeftOffset, y_constant * fontZoom),
+                text=string5, xy=(xLeftOffset, y_constant * fontZoom),
                 font=labelFont, fill=labelColor)
             y_constant += 15
-            if string4 != '':
+            if string5 != '':
                 im_drawer.text(
-                    text=string4, xy=(xLeftOffset, y_constant * fontZoom),
+                    text=string6, xy=(xLeftOffset, y_constant * fontZoom),
                     font=labelFont, fill=labelColor)
 
     def drawGeneBand(self, canvas, gifmap, plotXScale, offset=(40, 120, 80, 10), zoom=1, startMb=None, endMb=None):

--- a/wqflask/wqflask/marker_regression/run_mapping.py
+++ b/wqflask/wqflask/marker_regression/run_mapping.py
@@ -75,6 +75,7 @@ class RunMapping:
         self.vals = []
         self.samples = []
         self.sample_vals = start_vars['sample_vals']
+        self.vals_hash = start_vars['vals_hash']
         sample_val_dict = json.loads(self.sample_vals)
         samples = sample_val_dict.keys()
         if (len(genofile_samplelist) != 0):

--- a/wqflask/wqflask/static/new/javascript/show_trait_mapping_tools.js
+++ b/wqflask/wqflask/static/new/javascript/show_trait_mapping_tools.js
@@ -141,11 +141,11 @@ $('input[name=display_all]').change((function(_this) {
 })(this));
 
 //ZS: This is a list of inputs to be passed to the loading page, since not all inputs on the trait page are relevant to mapping
-var mapping_input_list = ['temp_uuid', 'trait_id', 'dataset', 'tool_used', 'form_url', 'method', 'transform', 'trimmed_markers', 'selected_chr', 'chromosomes', 'mapping_scale', 'sample_vals',
-                          'score_type', 'suggestive', 'significant', 'num_perm', 'permCheck', 'perm_output', 'perm_strata', 'categorical_vars', 'num_bootstrap', 'bootCheck', 'bootstrap_results',
-                          'LRSCheck', 'covariates', 'maf', 'use_loco', 'manhattan_plot', 'control_marker', 'do_control', 'genofile',
-                          'pair_scan', 'startMb', 'endMb', 'graphWidth', 'lrsMax', 'additiveCheck', 'showSNP', 'showGenes', 'viewLegend', 'haplotypeAnalystCheck', 
-                          'mapmethod_rqtl_geno', 'mapmodel_rqtl_geno', 'temp_trait', 'group', 'species', 'reaper_version', 'primary_samples']
+var mapping_input_list = ['temp_uuid', 'trait_id', 'dataset', 'tool_used', 'form_url', 'method', 'transform', 'trimmed_markers', 'selected_chr', 'chromosomes', 'mapping_scale',
+                          'sample_vals', 'vals_hash', 'score_type', 'suggestive', 'significant', 'num_perm', 'permCheck', 'perm_output', 'perm_strata', 'categorical_vars',
+                          'num_bootstrap', 'bootCheck', 'bootstrap_results', 'LRSCheck', 'covariates', 'maf', 'use_loco', 'manhattan_plot', 'control_marker',
+                          'do_control', 'genofile', 'pair_scan', 'startMb', 'endMb', 'graphWidth', 'lrsMax', 'additiveCheck', 'showSNP', 'showGenes', 'viewLegend',
+                          'haplotypeAnalystCheck', 'mapmethod_rqtl_geno', 'mapmodel_rqtl_geno', 'temp_trait', 'group', 'species', 'reaper_version', 'primary_samples']
 
 $(".rqtl-geno-tab, #rqtl_geno_compute").on("click", (function(_this) {
   return function() {

--- a/wqflask/wqflask/templates/loading.html
+++ b/wqflask/wqflask/templates/loading.html
@@ -12,6 +12,8 @@
           {% if start_vars.tool_used == "Mapping" %}
           <h1>Computing the Maps</h1>
           <br>
+          <b>Time Elapsed:</b> <span class="timer"></span>
+          <br>
           <b>Trait Metadata</b>
           <br>
           species = <b><i>{{ start_vars.species[0] | upper }}{{ start_vars.species[1:] }}</i></b>
@@ -101,9 +103,6 @@
 <script src="{{ url_for('js', filename='jquery/jquery.min.js') }}" type="text/javascript"></script>
 <script src="{{ url_for('js', filename='bootstrap/js/bootstrap.min.js') }}" type="text/javascript"></script>
 <script  type="text/javascript">
-$("#loading_form").attr("action", "{{ start_vars.form_url }}");
-setTimeout(function(){ $("#loading_form").submit()}, 350);
-
 $('#show_full_diff').click(function() {
   if ($('#diff_table_container').is(':visible')){
     $('#diff_table_container').hide();
@@ -111,4 +110,24 @@ $('#show_full_diff').click(function() {
     $('#diff_table_container').show();
   }
 })
+
+var start = new Date;
+
+setInterval(function() {
+  minutes = Math.floor((new Date - start) / 1000 / 60)
+  seconds = Math.round(((new Date - start) / 1000) % 60)
+  if (seconds < 10 && minutes >= 1){
+    seconds_text = "0" + seconds.toString()
+  } else {
+    seconds_text = seconds.toString()
+  }
+  if (minutes < 1) {
+    $('.timer').text(seconds_text + " seconds");
+  } else {
+    $('.timer').text(minutes.toString() + ":" + seconds_text);
+  }
+}, 100);
+
+$("#loading_form").attr("action", "{{ start_vars.form_url }}");
+setTimeout(function(){ $("#loading_form").submit()}, 350);
 </script>

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -34,6 +34,7 @@
         <input type="hidden" name="results_path" value="{{ mapping_results_path }}">
         <input type="hidden" name="method" value="{{ mapping_method }}">
         <input type="hidden" name="sample_vals" value="{{ sample_vals }}">
+        <input type="hidden" name="vals_hash" value="{{ vals_hash }}">
         <input type="hidden" name="n_samples" value="{{ n_samples }}">
         <input type="hidden" name="maf" value="{{ maf }}">
         <input type="hidden" name="use_loco" value="{{ use_loco }}">

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -68,7 +68,7 @@
               <h2>Map Viewer: Whole Genome</h2><br>
               <b>Population:</b> {{ dataset.group.species|capitalize }} {{ dataset.group.name }}<br>
               <b>Database:</b> {{ dataset.fullname }}<br>
-              {% if dataset.type == "ProbeSet" %}<b>Trait ID:</b>{% else %}<b>Record ID:</b>{% endif %} <a href="/show_trait?trait_id={{ this_trait.name }}&dataset={{ dataset.name }}">{{ this_trait.name }}</a><br>
+              {% if dataset.type == "ProbeSet" %}<b>Trait ID:</b>{% else %}<b>Record ID:</b>{% endif %} <a href="/show_trait?trait_id={{ this_trait.name }}&dataset={{ dataset.name }}">{{ this_trait.display_name }}</a><br>
               {% if dataset.type == "ProbeSet" %}
               <b>Gene Symbol:</b> <i>{{ this_trait.symbol }}</i><br>
               <b>Location:</b> Chr {{ this_trait.chr }} @ {{ this_trait.mb }} Mb<br>

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -1051,6 +1051,7 @@ def mapping_results_page():
         'samples',
         'vals',
         'sample_vals',
+        'vals_hash',
         'first_run',
         'output_files',
         'geno_db_exists',


### PR DESCRIPTION
#### Description
This updates the loading page and mapping results page to include some extra metadata:
- Time elapsed (for loading page)
- Sample values hash (for loading page and mapping figure)
- Current date/time (for mapping figure)
- Non-cofactor trait IDs are also fixed to include group codes (for phenotype traits)

#### How should this be tested?
Do any sort of mapping and check that this information is in the loading screen or results figure

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
