### PR TITLE
Adds Jupyter Notebook Launcher to Tools Dropdown Menu

### DIFF
--- a/wqflask/wqflask/templates/base.html
+++ b/wqflask/wqflask/templates/base.html
@@ -87,6 +87,7 @@
                                   <li><a href="https://systems-genetics.org/">Systems Genetics PheWAS</a></li>
                                   <li><a href="http://ucscbrowser.genenetwork.org/">Genome Browser</a></li>
                                   <li><a href="http://power.genenetwork.org">BXD Power Calculator</a></li>
+                                  <li><a href="http://notebook.genenetwork.org/">Jupyter Notebook Launcher</a></li>
                                   <li><a href="http://datafiles.genenetwork.org">Interplanetary File System</a></li>
                                 </ul>
                         </li>


### PR DESCRIPTION
This PR adds a dropdown menu item that points to the Jupyter Notebook Launcher app running at `notebook.genenetwork.org`.

Here's a screenshot of what it looks like:

![jupyter_embedded_gn2](https://user-images.githubusercontent.com/47760695/132798329-380a4b21-630a-4281-9a52-3271dba31432.png)

