### PR TITLE
Refactor/update authentication scripts

### DIFF
--- a/scripts/authentication/group.py
+++ b/scripts/authentication/group.py
@@ -133,7 +133,8 @@ if __name__ == "__main__":
 
     if not REDIS_CONN.hget("groups", data.get("field")):
         updated_data = json.loads(data["value"])
-        updated_data["created_timestamp"] = datetime.datetime.utcnow().strftime('%b %d %Y %I:%M%p')
+        timestamp = datetime.datetime.utcnow().strftime('%b %d %Y %I:%M%p')
+        updated_data["created_timestamp"] = timestamp
         data["value"] = json.dumps(updated_data)
 
     created_p = REDIS_CONN.hset(data.get("key", ""),

--- a/scripts/authentication/group.py
+++ b/scripts/authentication/group.py
@@ -41,6 +41,9 @@ def create_group_data(users: Dict, target_group: str,
     "field", and "value" that can be used in a redis hash as follows:
     HSET key field value
 
+    The "field" return value is a unique-id that is used to
+    distinguish the groups.
+
     Parameters:
 
     - `users`: a list of users for example:

--- a/scripts/authentication/group.py
+++ b/scripts/authentication/group.py
@@ -131,10 +131,10 @@ if __name__ == "__main__":
         members=members,
         admins=admins)
 
-      updated_data = json.loads(data["value"])
-      updated_data["created_timestamp"] = datetime.datetime.utcnow().strftime('%b %d %Y %I:%M%p')
-      data["value"] = json.dumps(updated_data)
     if not REDIS_CONN.hget("groups", data.get("field")):
+        updated_data = json.loads(data["value"])
+        updated_data["created_timestamp"] = datetime.datetime.utcnow().strftime('%b %d %Y %I:%M%p')
+        data["value"] = json.dumps(updated_data)
 
     created_p = REDIS_CONN.hset(data.get("key", ""),
                                 data.get("field", ""),

--- a/scripts/authentication/group.py
+++ b/scripts/authentication/group.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
                                 data.get("value", ""))
 
     groups = json.loads(REDIS_CONN.hget("groups",
-                                        args.group_name))  # type: ignore
+                                        data.get("field")))  # type: ignore
     if created_p:
         exit(f"\nSuccessfully created the group: '{args.group_name}'\n"
              f"`HGETALL groups {args.group_name}`: {groups}\n")

--- a/scripts/authentication/resource.py
+++ b/scripts/authentication/resource.py
@@ -63,12 +63,16 @@ def recover_hash(name: str, file_path: str, set_function) -> bool:
 if __name__ == "__main__":
     # Initialising the parser CLI arguments
     parser = argparse.ArgumentParser()
+    parser.add_argument("--group-id",
+                        help="Add the group id to all resources")
     parser.add_argument("--restore",
                         help="Restore from a given backup")
     parser.add_argument("--enable-backup", action="store_true",
                         help="Create a back up before edits")
     args = parser.parse_args()
 
+    if not args.group_id:
+        exit("Please specify the group-id!\n")
     if args.restore:
         if recover_hash(name="resources",
                         file_path=args.back_up,
@@ -92,8 +96,8 @@ if __name__ == "__main__":
 
     for resource_id, resource in RESOURCES.items():
         _resource = json.loads(resource)  # str -> dict conversion
-        _resource["group_masks"] = {"editors": {"metadata": "edit",
-                                                "data": "edit"}}
+        _resource["group_masks"] = {args.group_id: {"metadata": "edit",
+                                                    "data": "edit"}}
         REDIS_CONN.hset("resources",
                         resource_id,
                         json.dumps(_resource))


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->
This PR updates the `groups.py` and `resource.py` to use a unique id for the group. Now, when creating a new group, that group will be similar to:

```
1) "7fa95d07-0e2d-4bc5-b47c-448fdc1260b2"
2) "{\"name\": \"editors\", \"admins\": [], \"members\": [\"8ad942fe-490d-453e-bd37-56f252e41603\"], \"changed_timestamp\": \"Oct 06 2021 06:39PM\", \"created_timestamp\": \"Oct 06 2021 06:39PM\"}"
```

Now, when adding groups to resources, you should specify the "--group-id" flag as in:

```
guix environment -N -C --share=$HOME --ad-hoc python-wrapper python-glom python-redis -- \
     python resource.py --enable-backup --group-id=8ad942fe-490d-453e-bd37-56f252e41603
```

#### How should this be tested?
<!-- What should you do to test this PR? Is there any manual quality
assurance checks that should be done. What are the expectations -->
N/A

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->
Here's a commit that (accidentally) pushed to testing:

https://github.com/genenetwork/genenetwork2/commit/949789a00d8e6e901cc18b939737cd42e14c0236

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->
https://github.com/genenetwork/gn-gemtext-threads/blob/main/issues/authorisation.gmi

#### Screenshots (if appropriate)
N/A

#### Questions
<!-- Are there any questions for the reviewer -->
N/A