### PR TITLE
Feature/fix trait page js

### DIFF
--- a/wqflask/wqflask/show_trait/SampleList.py
+++ b/wqflask/wqflask/show_trait/SampleList.py
@@ -55,6 +55,7 @@ class SampleList:
                 except KeyError:
                     sample = webqtlCaseData.webqtlCaseData(name=sample_name)
 
+            sample.original_value = sample.value # This is to store the initial value so the value can be changed on the trait page
             sample.extra_info = {}
             if (self.dataset.group.name == 'AXBXA'
                     and sample_name in ('AXB18/19/20', 'AXB13/14', 'BXA8/17')):

--- a/wqflask/wqflask/static/new/javascript/initialize_show_trait_tables.js
+++ b/wqflask/wqflask/static/new/javascript/initialize_show_trait_tables.js
@@ -50,7 +50,7 @@ build_columns = function() {
         if (data.value == null) {
             return '<input type="text" data-value="x" data-qnorm="x" data-zscore="x" name="value:' + data.name + '" style="text-align: right;" class="trait_value_input edit_sample_value" value="x" size=' + js_data.max_digits[0] + '>'
         } else {
-            return '<input type="text" data-value="' + data.value.toFixed(3) + '" data-qnorm="' + js_data['qnorm_values'][0][parseInt(data.this_id) - 1] + '" data-zscore="' + js_data['zscore_values'][0][parseInt(data.this_id) - 1] + '" name="value:' + data.name + '" class="trait_value_input edit_sample_value" value="' + data.value.toFixed(3) + '" size=' + js_data.max_digits[0] + '>'
+            return '<input type="text" data-value="' + data.original_value.toFixed(3) + '" data-qnorm="' + js_data['qnorm_values'][0][parseInt(data.this_id) - 1] + '" data-zscore="' + js_data['zscore_values'][0][parseInt(data.this_id) - 1] + '" name="value:' + data.name + '" class="trait_value_input edit_sample_value" value="' + data.value.toFixed(3) + '" size=' + js_data.max_digits[0] + '>'
         }
       }
     }
@@ -168,8 +168,6 @@ if (js_data.sample_lists.length > 1){
 
 function loadDataTable(first_run=false, table_id, table_data){
 
-  console.log("COL DEFS:", columnDefs)
-
   if (!first_run){
     setUserColumnsDefWidths(table_id);
   }
@@ -181,11 +179,6 @@ function loadDataTable(first_run=false, table_id, table_data){
   }
 
   table_settings = {
-    'initComplete': function(settings, json) {
-    $('.edit_sample_value').change(function() {
-        edit_data_change();
-    });
-    },
     'createdRow': function ( row, data, index ) {
       $(row).attr('id', table_type + "_" + data.this_id)
       $(row).addClass("value_se");

--- a/wqflask/wqflask/static/new/javascript/stats.js
+++ b/wqflask/wqflask/static/new/javascript/stats.js
@@ -33,7 +33,8 @@ Stats = (function() {
     var is_odd, median_position, the_values_sorted;
     is_odd = this.the_values.length % 2;
     median_position = Math.floor(this.the_values.length / 2);
-    the_values_sorted = this.the_values.sort(function(a, b) {
+    let the_vals = [...this.the_values] // To prevent this.the_values from being sorted; there might be a better way to do this
+    the_values_sorted = the_vals.sort(function(a, b) {
       return a - b;
     });
     if (is_odd) {

--- a/wqflask/wqflask/templates/correlation_matrix.html
+++ b/wqflask/wqflask/templates/correlation_matrix.html
@@ -73,8 +73,13 @@
 <br>
 {% if pca_works == "True" %}
 <h2>PCA Traits</h2>
-<div style="margin-bottom: 20px; overflow:hidden;">
+<div style="margin-bottom: 20px; overflow:hidden; width: 450px;">
 <table id="pca_table" class="table-hover table-striped cell-border" id='trait_table' style="float: left;">
+  <colgroup>
+    <col span="1" style="width: 30px;">
+    <col span="1" style="width: 50px;">
+    <col span="1">
+ </colgroup>
   <thead>
   <tr>
     <th></th>


### PR DESCRIPTION
#### Description
This is intended to fix some issues with the trait page JS not working properly when a table is large enough to not load all rows into the DOM with Scroller. This required a number of changes due to the somewhat complex way the table interacts with the stats figures (and the way the table is built to begin with).

The biggest thing was changing the code that changed things via JQuery with code that changes the actual table data via the DataTables API, but this introduced some complications. The reset function previously used the data passed into the table as a "baseline" to revert to, so the original values needed to be stored in the data itself. Now each sample in SampleList also has a separate "original_value" field, so that the "value" can be changed.

Most of this will be in one large commit just because it was a long process of trial and error and I'm not sure how to split it up.

(Also I just noticed a commit setting the PCA trait table width is included in this, probably because I initially made it on testing branch but hadn't pushed it yet, so I guess that will be included with this; I wasn't originally planning on this being its own PR, but then it became sufficiently involved that I didn't want to push it directly)

#### How should this be tested?
Check that trait page functions work correctly, particularly with traits that have thousands of samples.

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
