### PR TITLE
Temporary fix to get temp trait submission working again; maybe shoul…

### DIFF
--- a/wqflask/wqflask/show_trait/show_trait.py
+++ b/wqflask/wqflask/show_trait/show_trait.py
@@ -40,10 +40,15 @@ ONE_YEAR = 60 * 60 * 24 * 365
 
 class ShowTrait:
     def __init__(self, user_id, kw):
+        self.admin_status = None
         if 'trait_id' in kw and kw['dataset'] != "Temp":
             self.temp_trait = False
             self.trait_id = kw['trait_id']
             helper_functions.get_species_dataset_trait(self, kw)
+            self.admin_status = get_highest_user_access_role(
+                    user_id=user_id,
+                    resource_id=(self.resource_id or ""),
+                    gn_proxy_url=GN_PROXY_URL)
         elif 'group' in kw:
             self.temp_trait = True
             self.trait_id = "Temp_" + kw['species'] + "_" + kw['group'] + \
@@ -73,10 +78,7 @@ class ShowTrait:
             self.trait_vals = Redis.get(self.trait_id).split()
         self.resource_id = get_resource_id(self.dataset,
                                            self.trait_id)
-        self.admin_status = get_highest_user_access_role(
-                user_id=user_id,
-                resource_id=(self.resource_id or ""),
-                gn_proxy_url=GN_PROXY_URL)
+
         # ZS: Get verify/rna-seq link URLs
         try:
             blatsequence = self.this_trait.blatseq

--- a/wqflask/wqflask/templates/show_trait_details.html
+++ b/wqflask/wqflask/templates/show_trait_details.html
@@ -234,7 +234,7 @@
         {% endif %}
         {% endif %}
         <button type="button" id="view_in_gn1" class="btn btn-primary" title="View Trait in GN1" onclick="window.open('http://gn1.genenetwork.org/webqtl/main.py?cmd=show&db={{ this_trait.dataset.name }}&probeset={{ this_trait.name }}', '_blank')">Go to GN1</button>
-        {% if admin_status.get('metadata', DataRole.VIEW) > DataRole.VIEW %}
+        {% if admin_status != None and admin_status.get('metadata', DataRole.VIEW) > DataRole.VIEW %}
         {% if this_trait.dataset.type == 'Publish' %}
         <button type="button" id="edit_resource" class="btn btn-success" title="Edit Resource" onclick="window.open('/datasets/{{ this_trait.dataset.id }}/traits/{{ this_trait.name }}?resource-id={{ resource_id }}', '_blank')">Edit</button>
         {% endif %}


### PR DESCRIPTION
#### Description
This is a temporary fix to an issue causing temp trait submission to not work (the GN3 authentication code isn't accounting for temp traits yet, but it probably shouldn't have to since I don't think temp traits will ever require any sort of authorization).

#### How should this be tested?
Check if submitting temp traits (and adding them to collections, etc) works properly

#### Any background context you want to provide?
The error occurs when calling this function (this fix just prevents calling the function for temp traits) - https://github.com/genenetwork/genenetwork3/blob/d28b823527b1eec1a99344da51abd139f97bfb64/gn3/authentication.py#L75-L100

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
