### PR TITLE
Bug/too many results search error

### DIFF
--- a/wqflask/wqflask/search_results.py
+++ b/wqflask/wqflask/search_results.py
@@ -62,8 +62,10 @@ class SearchResultPage:
             self.search_term_exists = True
 
         self.results = []
+        max_result_count = 100000 # max number of results to display
         type = kw.get('type')
         if type == "Phenotypes":     # split datatype on type field
+            max_result_count = 50000
             dataset_type = "Publish"
         elif type == "Genotypes":
             dataset_type = "Geno"
@@ -81,7 +83,7 @@ class SearchResultPage:
 
         self.too_many_results = False
         if self.search_term_exists:
-            if len(self.results) > 50000:
+            if len(self.results) > max_result_count:
                 self.trait_list = []
                 self.too_many_results = True
             else:

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -176,7 +176,7 @@
                 return params;
             };
 
-            {% if results|count > 0 %}
+            {% if results|count > 0  and not too_many_results %}
             var tableId = "trait_table";
 
             var width_change = 0; //ZS: For storing the change in width so overall table width can be adjusted by that amount


### PR DESCRIPTION
#### Description
Small PR to fix error that occurs if a search results too many results (higher than a threshold set in the code)

Also changes the threshold for different data types, since ProbeSet searches can quickly return a much larger number of results than phenotype ones currently

#### How should this be tested?
This query is the one that previously caused an error: https://genenetwork.org/search?species=mouse&group=BXD&type=Midbrain+mRNA&dataset=VUBXDMouseMidBrainQ0512&search_terms_or=*&search_terms_and=&FormID=searchResult

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
