### PR TITLE
bugfix:cases where trait symbol is none

### DIFF
--- a/wqflask/wqflask/correlation/correlation_gn3_api.py
+++ b/wqflask/wqflask/correlation/correlation_gn3_api.py
@@ -290,7 +290,7 @@ def get_tissue_correlation_input(this_trait, trait_symbol_dict):
     """Gets tissue expression values for the primary trait and target tissues values"""
     primary_trait_tissue_vals_dict = correlation_functions.get_trait_symbol_and_tissue_values(
         symbol_list=[this_trait.symbol])
-    if this_trait.symbol.lower() in primary_trait_tissue_vals_dict:
+    if this_trait.symbol  and this_trait.symbol.lower() in primary_trait_tissue_vals_dict:
         primary_trait_tissue_values = primary_trait_tissue_vals_dict[this_trait.symbol.lower(
         )]
         corr_result_tissue_vals_dict = correlation_functions.get_trait_symbol_and_tissue_values(


### PR DESCRIPTION
#### Description

this pr fixes edge cases where trait symbol is None raising error on method lower for nonetype
Example of failing case on correlation where we recompute tissue correlation
https://genenetwork.org/show_trait?trait_id=1445618_at&dataset=HC_M2_0606_P
<!--Brief description of the PR. What does this PR do? -->

#### How should this be tested?

<!-- What should you do to test this PR? Is there any manual quality
assurance checks that should be done. What are the expectations -->

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
