### PR TITLE
Fix mapping export error when trait symbols is None

### DIFF
--- a/wqflask/wqflask/marker_regression/run_mapping.py
+++ b/wqflask/wqflask/marker_regression/run_mapping.py
@@ -556,7 +556,8 @@ def export_mapping_results(dataset, trait, markers, results_path, mapping_method
                 transform_text = ""
             output_file.write(transform_text + "\n")
         if dataset.type == "ProbeSet":
-            output_file.write("Gene Symbol: " + trait.symbol + "\n")
+            if trait.symbol:
+                output_file.write("Gene Symbol: " + trait.symbol + "\n")
             output_file.write("Location: " + str(trait.chr) + \
                               " @ " + str(trait.mb) + " Mb\n")
         if len(covariates) > 0:


### PR DESCRIPTION
#### Description
Mapping was throwing an error for ProbeSet traits when there was no trait symbol. This just checks for a trait symbol.

This situation seems strange, since it's never happened before (which implies that traits have always had symbols in the past.

#### How should this be tested?
Do mapping with this trait: http://gn2-zach.genenetwork.org/show_trait?trait_id=1445618_at&dataset=HC_M2_0606_P

#### Any background context you want to provide?
Part of why I'm wondering if something funny is going on is that Alex apparently encountered a similar issue that he dealt with in this PR - https://github.com/genenetwork/genenetwork2/pull/626

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
