### PR TITLE
Fix gene global search

### DIFF
--- a/wqflask/wqflask/gsearch.py
+++ b/wqflask/wqflask/gsearch.py
@@ -82,12 +82,13 @@ class GSearch:
                     this_trait['species'] = line[0]
                     this_trait['group'] = line[1]
                     this_trait['tissue'] = line[2]
-                    this_trait['symbol'] = line[6]
+                    this_trait['symbol'] = "N/A"
+                    if line[6]:
+                        this_trait['symbol'] = line[6]
+                    this_trait['description'] = "N/A"
                     if line[7]:
                         this_trait['description'] = line[7].decode(
                             'utf-8', 'replace')
-                    else:
-                        this_trait['description'] = "N/A"
                     this_trait['location_repr'] = 'N/A'
                     if (line[8] != "NULL" and line[8] != "") and (line[9] != 0):
                         this_trait['location_repr'] = 'Chr%s: %.6f' % (


### PR DESCRIPTION
#### Description
Fixes gene global search error caused by gene symbol not being set

This seems to have only popped up recently, so it seems like previously gene symbol was always set in the DB (but now isn't). This change just sets a default if nothing is returned by the query.

#### How should this be tested?
Check that gene global search works, like with https://genenetwork.org/gsearch?type=gene&terms=Brca1

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
