### PR TITLE
Export collections/trait lists

### DIFF
--- a/wqflask/wqflask/static/new/css/trait_list.css
+++ b/wqflask/wqflask/static/new/css/trait_list.css
@@ -51,3 +51,12 @@ div.dts div.dataTables_scrollBody table {
 div.dts div.dataTables_paginate,div.dts div.dataTables_length{
     display:none
 }
+
+input.load_file {
+    display: inline;
+    background-color: #f5f5f5;
+    border-width: 1px;
+    border-style: solid;
+    border-color: #999999;
+    margin-left: 20px;
+}

--- a/wqflask/wqflask/templates/collections/view.html
+++ b/wqflask/wqflask/templates/collections/view.html
@@ -36,27 +36,27 @@
 
         <div>
             <br />
-	    <form id="heatmaps_form">
-	      <fieldset>
-		<legend>Heatmap Orientation</legend>
-		<label for="heatmap-orient-vertical">Vertical</label>
-		<input id="heatmap-orient-vertical"
-		       type="radio"
-		       name="vertical"
-		       value="true" />
-		<label for="heatmap-orient-horizontal">Horizontal</label>
-		<input id="heatmap-orient-horizontal"
-		       type="radio"
-		       name="vertical"
-		       value="false" />
-	      </fieldset>
-	      <button id="clustered-heatmap"
-		      class="btn btn-primary"
-		      data-url="{{heatmap_data_url}}"
-		      title="Generate heatmap from this collection">
-		Generate Heatmap
-	      </button>
-	    </form>
+            <form id="heatmaps_form">
+            <fieldset>
+            <legend>Heatmap Orientation</legend>
+            <label for="heatmap-orient-vertical">Vertical</label>
+            <input id="heatmap-orient-vertical"
+                type="radio"
+                name="vertical"
+                value="true" />
+            <label for="heatmap-orient-horizontal">Horizontal</label>
+            <input id="heatmap-orient-horizontal"
+                type="radio"
+                name="vertical"
+                value="false" />
+            </fieldset>
+            <button id="clustered-heatmap"
+                class="btn btn-primary"
+                data-url="{{heatmap_data_url}}"
+                title="Generate heatmap from this collection">
+            Generate Heatmap
+            </button>
+            </form>
 
             <div class="collection-table-options">
                 <form id="export_form" method="POST" action="/export_traits_csv">
@@ -74,8 +74,8 @@
                     <button id="delete" class="btn btn-danger submit_special" data-url="/collections/delete" type="button" title="Delete this collection" > Delete Collection</button>
                 </form>
             </div>
-	    <div id="clustered-heatmap-image-area">
-	    </div>
+            <div id="clustered-heatmap-image-area">
+            </div>
             <div style="margin-top: 10px; margin-bottom: 5px;">
                 <b>Show/Hide Columns:</b>
             </div>

--- a/wqflask/wqflask/templates/collections/view.html
+++ b/wqflask/wqflask/templates/collections/view.html
@@ -145,6 +145,13 @@
                 </table>
             </div>
             <br />
+            <form id="save_collection_form" method="POST" action="/save_collection"></form>
+                <div class="collection-table-options">
+                    <button class="btn btn-success" style="display: inline;" id="save_collection">Save Collection</button>
+                    <input type="file" name="load_file" size="15" class="load_file">
+                    <button class="btn btn-success" style="display: inline;" id="load_collection">Load Collection</button>
+                </div>
+            </form>
         </div>
     </div>
 


### PR DESCRIPTION
#### Description
This PR will add the option to export and load lists of traits from either collections or search results

#### How should this be tested?
Try saving/loading traits from the bottom of any collection or search results page

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
