### PR TITLE
Fix issue where mapping figure links weren't in the correct positions

### DIFF
--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -12,7 +12,7 @@
 {% endblock %}
 {% from "base_macro.html" import header %}
 {% block content %}
-    <div class="container" style="min-width: 900px;">
+    <div class="container" style="min-width: 1650px;">
         <form method="post" target="_blank" action="/run_mapping" name="marker_regression" id="marker_regression_form">
         <input type="hidden" name="temp_uuid" value="{{ temp_uuid }}">
         {% if temp_trait is defined %}


### PR DESCRIPTION
#### Description
Before this change, the mapping figure image's width could shrink to 900px, but the map element overlapping it (that contains the links for zooming into chromosomes, genes, etc) didn't, so if the browser window is smaller those links would appear not to work (since they wouldn't overlap with the correct parts of the image). This just changes the min-width of the container div to prevent the mapping image from every down-sizing. This is also probably why I didn't notice the issue, since I always have a maxed out browser window.

#### How should this be tested?
Do any mapping and check that links from the image work as expected.

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
