### PR TITLE
Bug/fix mapping image overflow

### DIFF
--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -2580,6 +2580,8 @@ class DisplayMappingResults:
                     if self.selectedChr != -1 and qtlresult['Mb'] > endMb:
                         Xc = startPosX + endMb * plotXScale
                     else:
+                        if qtlresult['Mb'] - startMb < 0:
+                            continue
                         Xc = startPosX + (qtlresult['Mb'] - startMb) * plotXScale
 
                 # updated by NL 06-18-2011:

--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -2471,12 +2471,6 @@ class DisplayMappingResults:
             thisLRSColor = self.colorCollection[0]
             if qtlresult['chr'] != previous_chr and self.selectedChr == -1:
                 if self.manhattan_plot != True:
-                    # im_drawer.polygon(
-                    #     xy=LRSCoordXY,
-                    #     outline=thisLRSColor
-                    #     # , closed=0, edgeWidth=lrsEdgeWidth,
-                    #     # clipX=(xLeftOffset, xLeftOffset + plotWidth)
-                    # )
                     draw_open_polygon(canvas, xy=LRSCoordXY,
                                       outline=thisLRSColor, width=lrsEdgeWidth)
 
@@ -2497,25 +2491,21 @@ class DisplayMappingResults:
                                     im_drawer.line(
                                         xy=((Xc0, Yc0), (Xcm, yZero)),
                                         fill=plusColor, width=lineWidth
-                                        # , clipX=(xLeftOffset, xLeftOffset + plotWidth)
                                     )
                                     im_drawer.line(
                                         xy=((Xcm, yZero),
                                             (Xc, yZero - (Yc - yZero))),
                                         fill=minusColor, width=lineWidth
-                                        # , clipX=(xLeftOffset, xLeftOffset + plotWidth)
                                     )
                                 else:
                                     im_drawer.line(
                                         xy=((Xc0, yZero - (Yc0 - yZero)),
                                             (Xcm, yZero)),
                                         fill=minusColor, width=lineWidth
-                                        # , clipX=(xLeftOffset, xLeftOffset + plotWidth)
                                     )
                                     im_drawer.line(
                                         xy=((Xcm, yZero), (Xc, Yc)),
                                         fill=plusColor, width=lineWidth
-                                        # , clipX=(xLeftOffset, xLeftOffset + plotWidth)
                                     )
                             elif (Yc0 - yZero) * (Yc - yZero) > 0:
                                 if Yc < yZero:
@@ -2523,14 +2513,12 @@ class DisplayMappingResults:
                                         xy=((Xc0, Yc0), (Xc, Yc)),
                                         fill=plusColor,
                                         width=lineWidth
-                                        # , clipX=(xLeftOffset, xLeftOffset + plotWidth)
                                     )
                                 else:
                                     im_drawer.line(
                                         xy=((Xc0, yZero - (Yc0 - yZero)),
                                             (Xc, yZero - (Yc - yZero))),
                                         fill=minusColor, width=lineWidth
-                                        # , clipX=(xLeftOffset, xLeftOffset + plotWidth)
                                     )
                             else:
                                 minYc = min(Yc - yZero, Yc0 - yZero)
@@ -2538,14 +2526,12 @@ class DisplayMappingResults:
                                     im_drawer.line(
                                         xy=((Xc0, Yc0), (Xc, Yc)),
                                         fill=plusColor, width=lineWidth
-                                        # , clipX=(xLeftOffset, xLeftOffset + plotWidth)
                                     )
                                 else:
                                     im_drawer.line(
                                         xy=((Xc0, yZero - (Yc0 - yZero)),
                                             (Xc, yZero - (Yc - yZero))),
                                         fill=minusColor, width=lineWidth
-                                        # , clipX=(xLeftOffset, xLeftOffset + plotWidth)
                                     )
 
                 LRSCoordXY = []
@@ -2558,22 +2544,21 @@ class DisplayMappingResults:
                     startPosX += newStartPosX
                     oldStartPosX = newStartPosX
 
-            # ZS: This is because the chromosome value stored in qtlresult['chr'] can be (for example) either X or 20 depending upon the mapping method/scale used
+            # This is because the chromosome value stored in qtlresult['chr'] can be (for example) either X or 20 depending upon the mapping method/scale used
             this_chr = str(self.ChrList[self.selectedChr][0])
             if self.plotScale != "physic":
                 this_chr = str(self.ChrList[self.selectedChr][1] + 1)
 
             if self.selectedChr == -1 or str(qtlresult['chr']) == this_chr:
                 if self.plotScale != "physic" and self.mapping_method == "reaper" and not self.manhattan_plot:
-                    Xc = startPosX + (qtlresult['cM'] - startMb) * plotXScale
+                    start_cm = self.genotype[self.selectedChr - 1][0].cM
+                    Xc = startPosX + (qtlresult['cM'] - start_cm) * plotXScale
                     if hasattr(self.genotype, "filler"):
                         if self.genotype.filler:
                             if self.selectedChr != -1:
-                                start_cm = self.genotype[self.selectedChr - 1][0].cM
                                 Xc = startPosX + \
                                     (qtlresult['Mb'] - start_cm) * plotXScale
                             else:
-                                start_cm = self.genotype[previous_chr_as_int][0].cM
                                 Xc = startPosX + ((qtlresult['Mb'] - start_cm - startMb) * plotXScale) * (
                                     ((qtlresult['Mb'] - start_cm - startMb) * plotXScale) / ((qtlresult['Mb'] - start_cm - startMb + self.GraphInterval) * plotXScale))
                 else:
@@ -2648,9 +2633,8 @@ class DisplayMappingResults:
                         AdditiveHeightThresh / additiveMax
                     AdditiveCoordXY.append((Xc, Yc))
 
-                if self.selectedChr != -1 and qtlresult['Mb'] > endMb:
+                if self.selectedChr != -1 and qtlresult['Mb'] > endMb and endMb != -1:
                     break
-
                 m += 1
 
         if self.manhattan_plot != True:

--- a/wqflask/wqflask/static/new/javascript/show_trait_mapping_tools.js
+++ b/wqflask/wqflask/static/new/javascript/show_trait_mapping_tools.js
@@ -177,6 +177,7 @@ $(".gemma-tab, #gemma_compute").on("click", (function(_this) {
       var form_data, url;
       url = "/loading";
       $('input[name=method]').val("gemma");
+      $('input[name=mapping_scale]').val('physic');
       $('input[name=selected_chr]').val($('#chr_gemma').val());
       $('input[name=num_perm]').val(0);
       $('input[name=genofile]').val($('#genofile_gemma').val());

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -39,6 +39,7 @@
         <input type="hidden" name="maf" value="{{ maf }}">
         <input type="hidden" name="use_loco" value="{{ use_loco }}">
         <input type="hidden" name="selected_chr" value="{{ selectedChr }}">
+        <input type="hidden" name="mapping_scale" value="{{ plotScale }}">
         <input type="hidden" name="manhattan_plot" value="{{ manhattan_plot }}">
         {% if manhattan_plot == True %}
         <input type="hidden" name="color_scheme" value="alternating">


### PR DESCRIPTION
#### Description
This should fix the issue where mapping results would sometimes run over the edges of the X-axis when zoomed into a Mb/cM range.

#### How should this be tested?
Try to zoom into a chromosome and/or Mb/cM range and check that the interval mapping line or manhattan plot points aren't being drawn outside of the X-axis.

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

#### Screenshots (if appropriate)

#### Questions
<!-- Are there any questions for the reviewer -->
