### PR TITLE
Fix LRS searches

### DIFF
--- a/wqflask/wqflask/do_search.py
+++ b/wqflask/wqflask/do_search.py
@@ -515,10 +515,7 @@ class LrsSearch(DoSearch):
 
         self.search_term = converted_search_term
 
-        if len(self.search_term) > 2:
-            from_clause = ", Geno"
-        else:
-            from_clause = ""
+        from_clause = ""
 
         return from_clause
 


### PR DESCRIPTION

LRS searches weren't working properly when they included the Chr/Mb parameters. This is because of a past change to allow Max LRS marker information to be fetched with a single query. Previously LRS searches with the Chr/Mb parameters would have to add ", Geno" to the FROM clause, but since the Geno table is already included now this caused it to appear twice, making the query not work.

To test, just do a search like: https://genenetwork.org/search?species=mouse&group=BXD&type=Hippocampus+mRNA&dataset=HC_M2_0606_P&search_terms_or=LRS%3D%289+999+Chr4+122+155%29&search_terms_and=&FormID=searchResult