### PR TITLE
Fix Global Search error

### DIFF
--- a/wqflask/wqflask/gsearch.py
+++ b/wqflask/wqflask/gsearch.py
@@ -119,7 +119,7 @@ class GSearch:
                     this_trait['dataset_id'] = line[15]
 
                     dataset_ob = SimpleNamespace(
-                        id=this_trait["dataset_id"], type="ProbeSet", species=this_trait["species"])
+                        id=this_trait["dataset_id"], type="ProbeSet", name=this_trait["dataset"], species=this_trait["species"])
                     if dataset_ob.id not in dataset_to_permissions:
                         permissions = check_resource_availability(dataset_ob)
                         dataset_to_permissions[dataset_ob.id] = permissions


### PR DESCRIPTION
Global search wasn't working because the SimpleNamespace now used for dataset_ob didn't include the dataset name, which is necessary in authentication if new traits are added (so this probably stopping working when new traits were added that didn't have their privileges set by Bonface's script when it was originally run).

This fixes that by just including the name.