### PR TITLE
Fix map horizontal scrolling

### DIFF
--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -12,7 +12,7 @@
 {% endblock %}
 {% from "base_macro.html" import header %}
 {% block content %}
-    <div class="container" style="min-width: 1650px;">
+    <div class="container">
         <form method="post" target="_blank" action="/run_mapping" name="marker_regression" id="marker_regression_form">
         <input type="hidden" name="temp_uuid" value="{{ temp_uuid }}">
         {% if temp_trait is defined %}


### PR DESCRIPTION
This removes min-width from a container div since it seems to have prevented horizontal scrolling for the mapping image (which is in another div inside of it). It should now be possible to horizontally scroll when the window is small.
