### PR TITLE
Fix Search Page Select All 

### DIFF
--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -446,7 +446,6 @@
                 "sDom": "iti",
                 "destroy": true,
                 "autoWidth": false,
-                "deferRender": true,
                 "bSortClasses": false,
                 "scrollY": "500px",
                 "scrollCollapse": true,


### PR DESCRIPTION
This just removes the deferRender setting from the search page DataTables configurations, because it prevents the DataTables API from having access to all rows (which makes functions like Select All only select a subset of rows when there are more than a couple hundred results).