### PR TITLE
Fix some search page issues

### DIFF
--- a/wqflask/wqflask/do_search.py
+++ b/wqflask/wqflask/do_search.py
@@ -343,7 +343,7 @@ class GenotypeSearch(DoSearch):
                 GenoFreeze.createtime as thistable,
                 Geno.Name as Geno_Name,
                 Geno.Source2 as Geno_Source2,
-                Geno.chr_num as Geno_chr_num,
+                Geno.Chr as Geno_Chr,
                 Geno.Mb as Geno_Mb
                 FROM GenoXRef, GenoFreeze, Geno """
 

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -25,9 +25,8 @@ change_buttons = function(check_node = 0) {
 };
 
 $(function() {
-  var add, checked_traits, deselectAll, invert, selectAll;
+  var selectAll, deselectAll, invert;
 
-  checked_traits = null;
   selectAll = function() {
     table_api = $('#trait_table').DataTable();
 
@@ -187,10 +186,6 @@ $(function() {
       href: "/collections/add?hash=" + traits_hash
     });
 
-  };
-
-  removedTraits = function() {
-    return checked_traits.closest("tr").fadeOut();
   };
 
   submitBnw = function() {

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -130,6 +130,13 @@ $(function() {
     })
   }
 
+  $(window).keydown(function(event){
+    if((event.keyCode == 13)) {
+      event.preventDefault();
+      return false;
+    }
+  });
+
   $('#select_top').keyup(function(event){
     if (event.keyCode === 13) {
       filter_by_index()

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -102,7 +102,13 @@ $(function() {
         try {
           start_index = parseInt(index_set.split("-")[0]);
           end_index = parseInt(index_set.split("-")[1]);
-          for (index = _j = start_index; start_index <= end_index ? _j <= end_index : _j >= end_index; index = start_index <= end_index ? ++_j : --_j) {
+
+          // If start index is higher than end index (for example is the string "10-5" exists) swap values so it'll be interpreted as "5-10" instead
+          if (start_index > end_index) {
+            [start_index, end_index] = [end_index, start_index]
+          }
+
+          for (index = start_index; index <= end_index; index++) {
             index_list.push(index);
           }
         } catch (_error) {

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -25,10 +25,10 @@ change_buttons = function(check_node = 0) {
 };
 
 $(function() {
-  var add, checked_traits, deselect_all, invert, remove, removed_traits, select_all;
+  var add, checked_traits, deselectAll, invert, selectAll;
 
   checked_traits = null;
-  select_all = function() {
+  selectAll = function() {
     table_api = $('#trait_table').DataTable();
 
     check_cells = table_api.column(0).nodes().to$();
@@ -44,7 +44,7 @@ $(function() {
     change_buttons();
   };
 
-  deselect_all = function() {
+  deselectAll = function() {
     table_api = $('#trait_table').DataTable();
 
     check_cells = table_api.column(0).nodes().to$();
@@ -93,7 +93,7 @@ $(function() {
       $('#trait_table').DataTable().search($(this).val()).draw();
   });
 
-  parse_index_string = function(idx_string) {
+  parseIndexString = function(idx_string) {
     index_list = [];
     _ref = idx_string.split(",");
     for (_i = 0; _i < _ref.length; _i++) {
@@ -117,9 +117,9 @@ $(function() {
     return new Set(index_list)
   }
 
-  filter_by_index = function() {
+  filterByIndex = function() {
     index_string = $('#select_top').val()
-    index_set = parse_index_string(index_string)
+    index_set = parseIndexString(index_string)
 
     table_api = $('#trait_table').DataTable();
     check_nodes = table_api.column(0).nodes().to$();
@@ -139,15 +139,15 @@ $(function() {
 
   $('#select_top').keyup(function(event){
     if (event.keyCode === 13) {
-      filter_by_index()
+      filterByIndex()
     }
   });
 
   $('#select_top').blur(function() {
-    filter_by_index()
+    filterByIndex()
   });
 
-  add_to_collection = function() {
+  addToCollection = function() {
     var traits;
     table_api = $('#trait_table').DataTable();
     check_nodes = table_api.column(0).nodes().to$();
@@ -174,19 +174,19 @@ $(function() {
 
   };
 
-  removed_traits = function() {
+  removedTraits = function() {
     return checked_traits.closest("tr").fadeOut();
   };
 
-  submit_bnw = function() {
-    trait_data = submit_traits_to_export_or_bnw("trait_table", "submit_bnw")
+  submitBnw = function() {
+    trait_data = submitTraitsToExportOrBnw("trait_table", "submit_bnw")
   }
 
-  export_traits = function() {
-    trait_data = submit_traits_to_export_or_bnw("trait_table", "export_csv")
+  exportTraits = function() {
+    trait_data = submitTraitsToExportOrBnw("trait_table", "export_csv")
   };
 
-  submit_traits_to_export_or_bnw = function(table_name, destination) {
+  submitTraitsToExportOrBnw = function(table_name, destination) {
     trait_table = $('#'+table_name);
     table_dict = {};
 
@@ -227,7 +227,7 @@ $(function() {
     $('#export_form').submit();
   };
 
-  get_traits_from_table = function(){
+  getTraitsFromTable = function(){
     traits = $("#trait_table input:checked").map(function() {
       return $(this).val();
     }).get();
@@ -243,42 +243,42 @@ $(function() {
   }
 
   $("#corr_matrix").on("click", function() {
-      traits = get_traits_from_table()
+      traits = getTraitsFromTable()
       $("#trait_list").val(traits)
       $("input[name=tool_used]").val("Correlation Matrix")
       $("input[name=form_url]").val($(this).data("url"))
       return submit_special("/loading")
   });
   $("#network_graph").on("click", function() {
-      traits = get_traits_from_table()
+      traits = getTraitsFromTable()
       $("#trait_list").val(traits)
       $("input[name=tool_used]").val("Network Graph")
       $("input[name=form_url]").val($(this).data("url"))
       return submit_special("/loading")
   });
   $("#wgcna_setup").on("click", function() {
-      traits = get_traits_from_table()
+      traits = getTraitsFromTable()
       $("#trait_list").val(traits)
       $("input[name=tool_used]").val("WGCNA Setup")
       $("input[name=form_url]").val($(this).data("url"))
       return submit_special("/loading")
   });
   $("#ctl_setup").on("click", function() {
-      traits = get_traits_from_table()
+      traits = getTraitsFromTable()
       $("#trait_list").val(traits)
       $("input[name=tool_used]").val("CTL Setup")
       $("input[name=form_url]").val($(this).data("url"))
       return submit_special("/loading")
   });
   $("#heatmap").on("click", function() {
-      traits = get_traits_from_table()
+      traits = getTraitsFromTable()
       $("#trait_list").val(traits)
       $("input[name=tool_used]").val("Heatmap")
       $("input[name=form_url]").val($(this).data("url"))
       return submit_special("/loading")
   });
   $("#comp_bar_chart").on("click", function() {
-      traits = get_traits_from_table()
+      traits = getTraitsFromTable()
       $("#trait_list").val(traits)
       $("input[name=tool_used]").val("Comparison Bar Chart")
       $("input[name=form_url]").val($(this).data("url"))
@@ -286,32 +286,32 @@ $(function() {
   });
 
   $("#send_to_webgestalt, #send_to_bnw, #send_to_geneweaver").on("click", function() {
-      traits = get_traits_from_table()
+      traits = getTraitsFromTable()
       $("#trait_list").val(traits)
       url = $(this).data("url")
       return submit_special(url)
   });
 
 
-  $("#select_all").click(select_all);
-  $("#deselect_all").click(deselect_all);
+  $("#select_all").click(selectAll);
+  $("#deselect_all").click(deselectAll);
   $("#invert").click(invert);
-  $("#add").click(add_to_collection);
-  $("#submit_bnw").click(submit_bnw);
-  $("#export_traits").click(export_traits);
+  $("#add").click(addToCollection);
+  $("#submit_bnw").click(submitBnw);
+  $("#export_traits").click(exportTraits);
 
   let naturalAsc = $.fn.dataTableExt.oSort["natural-ci-asc"]
   let naturalDesc = $.fn.dataTableExt.oSort["natural-ci-desc"]
 
   let na_equivalent_vals = ["N/A", "--", ""]; //ZS: Since there are multiple values that should be treated the same as N/A
 
-  function extract_inner_text(the_string){
+  function extractInnerText(the_string){
     var span = document.createElement('span');
     span.innerHTML = the_string;
     return span.textContent || span.innerText;
   }
 
-  function sort_NAs(a, b, sort_function){
+  function sortNAs(a, b, sort_function){
     if ( na_equivalent_vals.includes(a) && na_equivalent_vals.includes(b)) {
       return 0;
     }
@@ -326,10 +326,10 @@ $(function() {
 
   $.extend( $.fn.dataTableExt.oSort, {
     "natural-minus-na-asc": function (a, b) {
-      return sort_NAs(extract_inner_text(a), extract_inner_text(b), naturalAsc)
+      return sortNAs(extractInnerText(a), extractInnerText(b), naturalAsc)
     },
     "natural-minus-na-desc": function (a, b) {
-      return sort_NAs(extract_inner_text(a), extract_inner_text(b), naturalDesc)
+      return sortNAs(extractInnerText(a), extractInnerText(b), naturalDesc)
     }
   });
 
@@ -347,7 +347,7 @@ $(function() {
       } );
   }
 
-  apply_default = function() {
+  applyDefault = function() {
     let default_collection_id = $.cookie('default_collection');
     if (default_collection_id) {
       let the_option = $('[name=existing_collection] option').filter(function() {
@@ -356,6 +356,6 @@ $(function() {
       the_option.prop('selected', true);
     }
   }
-  apply_default();
+  applyDefault();
 
 });

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -93,6 +93,13 @@ $(function() {
       $('#trait_table').DataTable().search($(this).val()).draw();
   });
 
+  /**
+   * parseIndexString takes a string consisting of integers,
+   * hyphens, and/or commas to indicate range(s) of indices
+   * to select a rows and returns the corresponding set of indices
+   * For example - "1, 5-10, 15" would return a set of 8 rows
+   * @return {Set} The list of indices as a Set
+   */
   parseIndexString = function(idx_string) {
     index_list = [];
     _ref = idx_string.split(",");

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -96,7 +96,7 @@ $(function() {
   parse_index_string = function(idx_string) {
     index_list = [];
     _ref = idx_string.split(",");
-    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+    for (_i = 0; _i < _ref.length; _i++) {
       index_set = _ref[_i];
       if (index_set.indexOf('-') !== -1) {
         try {

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -25,7 +25,7 @@ change_buttons = function(check_node = 0) {
 };
 
 $(function() {
-  var selectAll, deselectAll, invert;
+  let selectAll, deselectAll, invert;
 
   selectAll = function() {
     table_api = $('#trait_table').DataTable();

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -132,14 +132,21 @@ $(function() {
   }
 
   filterByIndex = function() {
-    index_string = $('#select_top').val()
-    index_set = parseIndexString(index_string)
+    indexString = $('#select_top').val()
+    indexSet = parseIndexString(indexString)
 
-    table_api = $('#trait_table').DataTable();
-    check_nodes = table_api.column(0).nodes().to$();
-    check_nodes.each(function(index) {
-      if (index_set.has(index + 1)){
+    tableApi = $('#trait_table').DataTable();
+    checkNodes = tableApi.column(0).nodes().to$();
+    checkNodes.each(function(index) {
+      if (indexSet.has(index + 1)){
         $(this)[0].childNodes[0].checked = true
+      }
+    })
+
+    checkRows = tableApi.rows().nodes().to$();
+    checkRows.each(function(index) {
+      if (indexSet.has(index + 1)){
+        $(this)[0].classList.add("selected");
       }
     })
   }

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -132,9 +132,13 @@ $(function() {
 
   add_to_collection = function() {
     var traits;
-    traits = $("#trait_table input:checked").map(function() {
-      return $(this).val();
-    }).get();
+    table_api = $('#trait_table').DataTable();
+    check_nodes = table_api.column(0).nodes().to$();
+    traits = Array.from(check_nodes.map(function() {
+      if ($(this)[0].childNodes[0].checked){
+        return $(this)[0].childNodes[0].value
+      }
+    }))
 
     var traits_hash = md5(traits.toString());
 

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -102,11 +102,17 @@ $(function() {
    */
   parseIndexString = function(idx_string) {
     index_list = [];
+
     _ref = idx_string.split(",");
     for (_i = 0; _i < _ref.length; _i++) {
       index_set = _ref[_i];
+      if (!/^ *([0-9]+$) *| *([0-9]+ *- *[0-9]+$) *|(^$)$/.test(index_set)) {
+        $('#select_samples_invalid').show();
+        break
+      } else {
+        $('#select_samples_invalid').hide();
+      }
       if (index_set.indexOf('-') !== -1) {
-        try {
           start_index = parseInt(index_set.split("-")[0]);
           end_index = parseInt(index_set.split("-")[1]);
 
@@ -118,10 +124,6 @@ $(function() {
           for (index = start_index; index <= end_index; index++) {
             index_list.push(index);
           }
-        } catch (_error) {
-          error = _error;
-          alert("Syntax error");
-        }
       } else {
         index = parseInt(index_set);
         index_list.push(index);

--- a/wqflask/wqflask/static/new/javascript/search_results.js
+++ b/wqflask/wqflask/static/new/javascript/search_results.js
@@ -93,41 +93,51 @@ $(function() {
       $('#trait_table').DataTable().search($(this).val()).draw();
   });
 
-  $('#select_top').keyup(function(){
-      num_rows = $(this).val()
-
-      if (num_rows = parseInt(num_rows)){
-          table_api = $('#trait_table').DataTable();
-
-          check_cells = table_api.column(0).nodes().to$();
-          for (let i = 0; i < num_rows; i++) {
-            check_cells[i].childNodes[0].checked = true;
+  parse_index_string = function(idx_string) {
+    index_list = [];
+    _ref = idx_string.split(",");
+    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+      index_set = _ref[_i];
+      if (index_set.indexOf('-') !== -1) {
+        try {
+          start_index = parseInt(index_set.split("-")[0]);
+          end_index = parseInt(index_set.split("-")[1]);
+          for (index = _j = start_index; start_index <= end_index ? _j <= end_index : _j >= end_index; index = start_index <= end_index ? ++_j : --_j) {
+            index_list.push(index);
           }
-
-          check_rows = table_api.rows().nodes();
-          for (let i=0; i < num_rows; i++) {
-            if (check_rows[i].classList.contains("selected")){
-              continue
-            } else {
-              check_rows[i].classList.add("selected")
-            }
-          }
-          for (let i = num_rows; i < check_rows.length; i++){
-            check_cells[i].childNodes[0].checked = false;
-            if (check_rows[i].classList.contains("selected")){
-              check_rows[i].classList.remove("selected")
-            }
-          }
-      }
-      else {
-        for (let i = 0; i < check_rows.length; i++){
-          check_cells[i].childNodes[0].checked = false;
-          if (check_rows[i].classList.contains("selected")){
-            check_rows[i].classList.remove("selected")
-          }
+        } catch (_error) {
+          error = _error;
+          alert("Syntax error");
         }
+      } else {
+        index = parseInt(index_set);
+        index_list.push(index);
       }
-      change_buttons();
+    }
+    return new Set(index_list)
+  }
+
+  filter_by_index = function() {
+    index_string = $('#select_top').val()
+    index_set = parse_index_string(index_string)
+
+    table_api = $('#trait_table').DataTable();
+    check_nodes = table_api.column(0).nodes().to$();
+    check_nodes.each(function(index) {
+      if (index_set.has(index + 1)){
+        $(this)[0].childNodes[0].checked = true
+      }
+    })
+  }
+
+  $('#select_top').keyup(function(event){
+    if (event.keyCode === 13) {
+      filter_by_index()
+    }
+  });
+
+  $('#select_top').blur(function() {
+    filter_by_index()
   });
 
   add_to_collection = function() {

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -102,6 +102,10 @@
               <button class="btn btn-default" id="invert" type="button"><span class="glyphicon glyphicon-adjust"></span> Invert</button>
               <button class="btn btn-default" id="deselect_all" type="button"><span class="glyphicon glyphicon-remove"></span> Deselect</button>
             </div>
+            <div id="select_samples_invalid" class="alert alert-error" style="display:none;">
+              Please check that your syntax includes only a combination of integers, dashes, and commas of a format 
+              similar to <strong>1,5,10</strong> or <strong>2, 5-10, 15</strong>, etc.
+            </div>
           </form>
           {% if dataset.type != 'Geno' %}
           <div class="show-hide-container">

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -105,7 +105,7 @@
           </form>
           {% if dataset.type != 'Geno' %}
           <div class="show-hide-container">
-            <b>Show/Hide Columns:</b>
+            <b>Show/Hide Columns:&nbsp;</b>
             <br>
             {% if dataset.type == 'ProbeSet' %}
             <button class="toggle-vis" data-column="3">Symbol</button>

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -232,7 +232,7 @@
             {
               'title': "<div style='text-align: right;'>Location</div>",
               'type': "natural-minus-na",
-              'width': "125px",
+              'width': "130px",
               'targets': 5,
               'data': "location"
             },
@@ -255,7 +255,7 @@
             {
               'title': "<div style='text-align: right;'>Peak Location</div>",
               'type': "natural-minus-na",
-              'width': "125px",
+              'width': "130px",
               'targets': 8,
               'data': "lrs_location"
             },
@@ -349,7 +349,7 @@
             {
               'title': "<div style='text-align: right;'>Peak Location</div>",
               'type': "natural-minus-na",
-              'width': "120px",
+              'width': "125px",
               'targets': 8,
               'data': "lrs_location"
             },
@@ -374,7 +374,7 @@
             {
               'title': "<div style='text-align: right;'>Location</div>",
               'type': "natural-minus-na",
-              'width': "120px",
+              'width': "125px",
               'targets': 2,
               'data': "location"
             }{% endif %}

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -447,7 +447,7 @@
                 "destroy": true,
                 "autoWidth": false,
                 "bSortClasses": false,
-                "scrollY": "500px",
+                "scrollY": "1000px",
                 "scrollCollapse": true,
                 {% if trait_list|length > 5 %}
                 "scroller":  true,

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -105,8 +105,7 @@
           </form>
           {% if dataset.type != 'Geno' %}
           <div class="show-hide-container">
-            <b>Show/Hide Columns:&nbsp;</b>
-            <br>
+            <b>Show/Hide Columns:&nbsp;&nbsp;</b>
             {% if dataset.type == 'ProbeSet' %}
             <button class="toggle-vis" data-column="3">Symbol</button>
             <button class="toggle-vis" data-column="4">Description</button>

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -245,7 +245,7 @@
               'orderSequence': [ "desc", "asc"]
             },
             {
-              'title': "<div>Peak <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\"><sup>&nbsp;?</sup></a></div><div>LOD&ensp;&emsp;</div>",
+              'title': "<div>Peak <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div><div>LOD&ensp;&emsp;</div>",
               'type': "natural-minus-na",
               'data': "lod_score",
               'width': "60px",
@@ -260,7 +260,7 @@
               'data': "lrs_location"
             },
             {
-              'title': "<div>Effect <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\"><sup>&nbsp;?</sup></a></div><div>Size&ensp;&emsp;</div>",
+              'title': "<div>Effect <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div><div>Size&ensp;&emsp;</div>",
               'type': "natural-minus-na",
               'data': "additive",
               'width': "65px",
@@ -339,7 +339,7 @@
               'orderSequence': [ "desc", "asc"]
             },
             {
-              'title': "<div>Peak <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\"><sup>&nbsp;?</sup></a></div><div>LOD&ensp;&emsp;</div>",
+              'title': "<div>Peak <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div><div>LOD&ensp;&emsp;</div>",
               'type': "natural-minus-na",
               'data': "lod_score",
               'targets': 7,
@@ -354,7 +354,7 @@
               'data': "lrs_location"
             },
             {
-              'title': "<div>Effect <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\"><sup>&nbsp;?</sup></a></div><div>Size&ensp;&emsp;</div>",
+              'title': "<div>Effect <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div><div>Size&ensp;&emsp;</div>",
               'type': "natural-minus-na",
               'width': "60px",
               'data': "additive",

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -247,7 +247,7 @@
               'orderSequence': [ "desc", "asc"]
             },
             {
-              'title': "<div>Peak <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div><div>LOD&ensp;&emsp;</div>",
+              'title': "<div style='text-align: right; padding-right: 10px;'>Peak</div> <div style='text-align: right;'>LOD <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div>",
               'type': "natural-minus-na",
               'data': "lod_score",
               'width': "60px",
@@ -262,7 +262,7 @@
               'data': "lrs_location"
             },
             {
-              'title': "<div>Effect <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div><div>Size&ensp;&emsp;</div>",
+              'title': "<div style='text-align: right; padding-right: 10px;'>Effect</div> <div style='text-align: right;'>Size <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div>",
               'type': "natural-minus-na",
               'data': "additive",
               'width': "65px",
@@ -341,7 +341,7 @@
               'orderSequence': [ "desc", "asc"]
             },
             {
-              'title': "<div>Peak <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div><div>LOD&ensp;&emsp;</div>",
+              'title': "<div style='text-align: right; padding-right: 10px;'>Peak</div> <div style='text-align: right;'>LOD <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div>",
               'type': "natural-minus-na",
               'data': "lod_score",
               'targets': 7,
@@ -356,7 +356,7 @@
               'data': "lrs_location"
             },
             {
-              'title': "<div>Effect <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div><div>Size&ensp;&emsp;</div>",
+              'title': "<div style='text-align: right; padding-right: 10px;'>Effect</div> <div style='text-align: right;'>Size <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\"><sup style='color: #FF0000;'><i>?</i></sup></a></div>",
               'type': "natural-minus-na",
               'width': "60px",
               'data': "additive",

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -97,7 +97,7 @@
               <input type="text" id="searchbox" class="form-control" style="width: 200px; display: inline;" placeholder="Search This Table For ...">
               <button class="btn btn-success" id="add" type="button" disabled><span class="glyphicon glyphicon-plus-sign"></span> Add</button>
               <button class="btn btn-default" id="select_all" type="button"><span class="glyphicon glyphicon-ok"></span> Select All</button>
-              <input type="text" id="select_top" class="form-control" style="width: 200px; display: inline;" placeholder="Select Top ...">
+              <input type="text" id="select_top" class="form-control" style="width: 200px; display: inline;" placeholder="Select Rows (1-5, 11)">
               <button class="btn btn-default" id="export_traits"><span class="glyphicon glyphicon-download"></span> Download</button>
               <button class="btn btn-default" id="invert" type="button"><span class="glyphicon glyphicon-adjust"></span> Invert</button>
               <button class="btn btn-default" id="deselect_all" type="button"><span class="glyphicon glyphicon-remove"></span> Deselect</button>

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -195,6 +195,8 @@
               'title': "Index",
               'type': "natural",
               'width': "35px",
+              "searchable": false,
+              "orderable": false,
               'targets': 1,
               'data': "index"
             }
@@ -490,6 +492,12 @@
                 {% endif %}
               }
             }
+
+            trait_table.on( 'order.dt search.dt', function () {
+              trait_table.column(1, {search:'applied', order:'applied'}).nodes().each( function (cell, i) {
+                cell.innerHTML = i+1;
+              } );
+            } ).draw();
 
             window.addEventListener('resize', function(){
               trait_table.columns.adjust();

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -94,12 +94,12 @@
               <input type="hidden" name="accession_id" id="accession_id" value="{{ dataset.accession_id }}">
               {% endif %}
               <input type="hidden" name="export_data" id="export_data" value="">
-              <button class="btn btn-default" id="select_all" type="button"><span class="glyphicon glyphicon-ok"></span> Select</button>
-              <button class="btn btn-default" id="invert" type="button"><span class="glyphicon glyphicon-adjust"></span> Invert</button>
-              <button class="btn btn-success" id="add" type="button" disabled><span class="glyphicon glyphicon-plus-sign"></span> Add</button>
-              <button class="btn btn-default" id="export_traits">Download <span class="glyphicon glyphicon-download"></span></button>
               <input type="text" id="searchbox" class="form-control" style="width: 200px; display: inline;" placeholder="Search This Table For ...">
+              <button class="btn btn-success" id="add" type="button" disabled><span class="glyphicon glyphicon-plus-sign"></span> Add</button>
+              <button class="btn btn-default" id="select_all" type="button"><span class="glyphicon glyphicon-ok"></span> Select All</button>
               <input type="text" id="select_top" class="form-control" style="width: 200px; display: inline;" placeholder="Select Top ...">
+              <button class="btn btn-default" id="export_traits"><span class="glyphicon glyphicon-download"></span> Download</button>
+              <button class="btn btn-default" id="invert" type="button"><span class="glyphicon glyphicon-adjust"></span> Invert</button>
               <button class="btn btn-default" id="deselect_all" type="button"><span class="glyphicon glyphicon-remove"></span> Deselect</button>
             </div>
           </form>

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -126,7 +126,7 @@
             {% endif %}
           </div>
           {% endif %}
-          <div id="table_container" style="width: {% if dataset.type == 'Geno' %}270{% else %}100%{% endif %}px;">
+          <div id="table_container" style="width: {% if dataset.type == 'Geno' %}375{% else %}100%{% endif %}px;">
             <table class="table-hover table-striped cell-border" id='trait_table' style="float: left;">
                 <tbody>
                  <td colspan="100%" align="center"><br><b><font size="15">Loading...</font></b><br></td>

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -245,7 +245,7 @@
               'orderSequence': [ "desc", "asc"]
             },
             {
-              'title': "<div style='text-align: right;'>Peak <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\">&nbsp;<i class=\"fa fa-info-circle\" aria-hidden=\"true\"></i></a></div><div style='text-align: right;'>LOD&ensp;&emsp;</div>",
+              'title': "<div>Peak <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\"><sup>&nbsp;?</sup></a></div><div>LOD&ensp;&emsp;</div>",
               'type': "natural-minus-na",
               'data': "lod_score",
               'width': "60px",
@@ -260,7 +260,7 @@
               'data': "lrs_location"
             },
             {
-              'title': "<div style='text-align: right;'>Effect <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\">&nbsp;<i class=\"fa fa-info-circle\" aria-hidden=\"true\"></i></a></div><div style='text-align: right;'>Size&ensp;&emsp;</div>",
+              'title': "<div>Effect <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\"><sup>&nbsp;?</sup></a></div><div>Size&ensp;&emsp;</div>",
               'type': "natural-minus-na",
               'data': "additive",
               'width': "65px",
@@ -339,7 +339,7 @@
               'orderSequence': [ "desc", "asc"]
             },
             {
-              'title': "<div style='text-align: right;'>Peak <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\">&nbsp;<i class=\"fa fa-info-circle\" aria-hidden=\"true\"></i></a></div><div style='text-align: right;'>LOD&ensp;&emsp;</div>",
+              'title': "<div>Peak <a href=\"{{ url_for('glossary_blueprint.glossary') }}#LRS\" target=\"_blank\" style=\"color: white;\"><sup>&nbsp;?</sup></a></div><div>LOD&ensp;&emsp;</div>",
               'type': "natural-minus-na",
               'data': "lod_score",
               'targets': 7,
@@ -354,7 +354,7 @@
               'data': "lrs_location"
             },
             {
-              'title': "<div style='text-align: right;'>Effect <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\">&nbsp;<i class=\"fa fa-info-circle\" aria-hidden=\"true\"></i></a></div><div style='text-align: right;'>Size&ensp;&emsp;</div>",
+              'title': "<div>Effect <a href=\"{{ url_for('glossary_blueprint.glossary') }}#A\" target=\"_blank\" style=\"color: white;\"><sup>&nbsp;?</sup></a></div><div>Size&ensp;&emsp;</div>",
               'type': "natural-minus-na",
               'width': "60px",
               'data': "additive",

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -94,7 +94,7 @@
               <input type="hidden" name="accession_id" id="accession_id" value="{{ dataset.accession_id }}">
               {% endif %}
               <input type="hidden" name="export_data" id="export_data" value="">
-              <input type="text" id="searchbox" class="form-control" style="width: 200px; display: inline;" placeholder="Search This Table For ...">
+              <input type="text" id="searchbox" class="form-control" style="width: 200px; display: inline;" placeholder="Search For...">
               <button class="btn btn-success" id="add" type="button" disabled><span class="glyphicon glyphicon-plus-sign"></span> Add</button>
               <button class="btn btn-default" id="select_all" type="button"><span class="glyphicon glyphicon-ok"></span> Select All</button>
               <input type="text" id="select_top" class="form-control" style="width: 200px; display: inline;" placeholder="Select Rows (1-5, 11)">


### PR DESCRIPTION
This PR fixes a few issues:

- There was a bug where you could only add a limited number of rows to a collection at once (this is by far the most important issue). This is because the JS was still using JQuery to select rows, which doesn't select all rows if a table is using Scroller and has more than 150-200 rows (since Scroller doesn't load all rows in). I just changed the JS to use the DataTables API instead. There's still a remaining unrelated issue where loading the View Collection page is very slow.
- Fixes an issue where Genotype dataset queries were fetching from the Geno.chr_num column instead of Geno.Chr column. At least some datasets don't have any value set in the chr_num columns, leading some searches to return unknown chromosomes for the locations in their results.
- Fixed some aesthetic issues, most of which seemed to be unique to certain environments (so there might need to be further updates as I check with Rob to see if he still has issues). Most of these involve changing widths - the more detailed descriptions are in the commits.
