### PR TITLE
Fix/consider within 3dp values on data upload

### DIFF
--- a/wqflask/wqflask/user_login.py
+++ b/wqflask/wqflask/user_login.py
@@ -177,8 +177,6 @@ def verify_email():
 @app.route("/n/login", methods=('GET', 'POST'))
 def login():
     params = request.form if request.form else request.args
-    logger.debug("in login params are:", params)
-
     if not params:  # ZS: If coming to page for first time
         from utility.tools import GITHUB_AUTH_URL, GITHUB_CLIENT_ID, ORCID_AUTH_URL, ORCID_CLIENT_ID
         external_login = {}


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->
Fixed precision point errors.  During file upload, excel appended
extra values; so instead of `BXD1,18.8,x,x`, you'd have
`BXD1,18.8000001,20,x`.  There are 2 parts to fixing this:

- During generating the JSON file(when creating the diff), ignore
  modifications where |ε| > 0.001.

- When listing diffs, ignore modification entries where |ε| > 0.001.

For this fix, the second bit was ignored, because it'll lead to
unnecessarily complicated code, given that only one person has really
been testing the system.

#### How should this be tested?
<!-- What should you do to test this PR? Is there any manual quality
assurance checks that should be done. What are the expectations -->

N/A

#### Any background context you want to provide?
<!-- Anything the reviewer should be aware of ahead of testing -->

N/A

#### What are the relevant pivotal tracker stories?
<!-- Does this PR track anything anywhere? -->

https://github.com/genenetwork/gn-gemtext-threads/commit/eb435b76b3433ed97837299329229e919c3fffd6

#### Screenshots (if appropriate)

N/A

#### Questions
<!-- Are there any questions for the reviewer -->
N/A
