### PR TITLE
Fix CSV Download link

### DIFF
--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -217,7 +217,7 @@
         </div>
     </div>
     <div style="margin-left: 13%;">
-        <a href="/datasets/{{ publish_xref.id_ }}/traits/{{ publish_xref.phenotype_id }}/csv?resource-id={{ resource_id }}" class="btn btn-link btn-sm">
+        <a href="/datasets/{{ publish_xref.id_ }}/traits/{{ publish_xref.inbred_set_id }}/csv?resource-id={{ resource_id }}" class="btn btn-link btn-sm">
             Sample Data(CSV Download)
         </a>
     </div>


### PR DESCRIPTION
This just changes the CSV download link in edit_phenotype.html to take the inbred_set_id as a parameter instead of phenotype ID (since the combination of PublishXRef.Id and PublishXRef.InbredSetId is the best way to identify a trait). There's a separate GN3 PR changing the query on that end.
