### PR TITLE
Bug/fix search terms

### DIFF
--- a/wqflask/wqflask/do_search.py
+++ b/wqflask/wqflask/do_search.py
@@ -609,9 +609,6 @@ class PhenotypeLrsSearch(LrsSearch, PhenotypeSearch):
 
 class CisTransLrsSearch(DoSearch):
 
-    def get_from_clause(self):
-        return ", Geno"
-
     def get_where_clause(self, cis_trans):
         self.mb_buffer = 5  # default
         chromosome = None

--- a/wqflask/wqflask/templates/search_result_page.html
+++ b/wqflask/wqflask/templates/search_result_page.html
@@ -40,6 +40,8 @@
                     with <u>{{ word.key|upper }}</u> between <strong>{{ word.search_term[0] }}</strong> and <strong>{{ word.search_term[1] }}</strong>{% if loop.last %}.{% else %} and {% endif %}
                     {% elif word.search_term|length == 3 %}
                     with <u>{{ word.key|upper }}</u> between <strong>{{ word.search_term[0] }}</strong> and <strong>{{ word.search_term[1] }}</strong> on chromosome <strong>{{ word.search_term[2] }}</strong>{% if loop.last %}.{% else %} and {% endif %}
+                    {% elif word.search_term|length == 4 %}
+                    with <u>{{ word.key|upper }}</u> between <strong>{{ word.search_term[0] }}</strong> and <strong>{{ word.search_term[1] }}</strong> on chromosome <strong>{{ word.search_term[3] }}</strong> with an exclusion zone of <strong>{{ word.search_term[2] }}</strong> Mb
                     {% elif word.search_term|length == 5 %}
                     with <u>{{ word.key|upper }}</u> between <strong>{{ word.search_term[0] }}</strong> and <strong>{{ word.search_term[1] }}</strong> on chromosome <strong>{{ word.search_term[2] }}</strong> between <strong>{{ word.search_term[3] }}</strong> and <strong>{{ word.search_term[4] }}</strong> Mb{% if loop.last %}.{% else %} and {% endif %}
                     {% endif %}


### PR DESCRIPTION
This fixes a bug that was causing cis/trans LRS/LOD searches to not work properly.

The bug was caused by a mistake in the SQL where the Geno table was included in the FROM clause even though it was already included in a JOIN.

I also added some description text for cis/trans LRS/LOD searches with 4 terms (so a chromosome and exclusion zone specified), since there wasn't any before.
