### PR TITLE
Chore/fix pcorr table

### DIFF
--- a/wqflask/wqflask/static/new/css/partial_correlations.css
+++ b/wqflask/wqflask/static/new/css/partial_correlations.css
@@ -30,11 +30,6 @@ tr:nth-of-type(2n) {
     background: #F9F9F9;
 }
 
-thead tr {
-    background: #336699;
-    line-height: 1.5em;
-}
-
 .with-trait {
     margin-left: 0.7em;
     position: relative;

--- a/wqflask/wqflask/static/new/javascript/partial_correlations.js
+++ b/wqflask/wqflask/static/new/javascript/partial_correlations.js
@@ -249,6 +249,8 @@ function display_partial_corr_results(data, status, xhr) {
 	data["results"]["control_traits"],
 	data["results"]["correlations"],
 	data["results"]["method"]);
+
+	initializePcorrTable(data["results"]["dataset_type"]);
 }
 
 function display_partial_corr_error(xhr, status, error) {
@@ -283,6 +285,40 @@ function send_data_and_process_results(
 	success: success_fn,
 	error: error_fn
     });
+}
+
+function initializePcorrTable(dataType){
+	tableId = "part-corr-results-" + dataType.toLowerCase();
+	if (dataType == "Publish") {
+		orderCol = 7;
+	} else if (dataType == "ProbeSet") {
+		orderCol = 11;
+	} else {
+		orderCol = 6;
+	}
+
+	$('#' + tableId).dataTable( {
+		'drawCallback': function( settings ) {
+			  $('#' + tableId + ' tr').off().on("click", function(event) {
+				if (event.target.type !== 'checkbox' && event.target.tagName.toLowerCase() !== 'a') {
+				  var obj =$(this).find('input');
+				  obj.prop('checked', !obj.is(':checked'));
+				}
+				if ($(this).hasClass("selected") && event.target.tagName.toLowerCase() !== 'a'){
+				  $(this).removeClass("selected")
+				} else if (event.target.tagName.toLowerCase() !== 'a') {
+				  $(this).addClass("selected")
+				}
+			  });
+		},
+		"order": [[orderCol, "asc" ]],
+		"sDom": "itir",
+		"iDisplayLength": -1,
+		"autoWidth": false,
+		"bDeferRender": true,
+		"bSortClasses": false,
+		"paging": false
+	} );
 }
 
 $("#partial-correlations-form").submit(function(e) {

--- a/wqflask/wqflask/static/new/javascript/partial_correlations.js
+++ b/wqflask/wqflask/static/new/javascript/partial_correlations.js
@@ -290,11 +290,11 @@ function send_data_and_process_results(
 function initializePcorrTable(dataType){
 	tableId = "part-corr-results-" + dataType.toLowerCase();
 	if (dataType == "Publish") {
-		orderCol = 7;
+		orderCol = 8;
 	} else if (dataType == "ProbeSet") {
-		orderCol = 11;
+		orderCol = 12;
 	} else {
-		orderCol = 6;
+		orderCol = 7;
 	}
 
 	$('#' + tableId).dataTable( {

--- a/wqflask/wqflask/templates/partial_correlations.html
+++ b/wqflask/wqflask/templates/partial_correlations.html
@@ -10,6 +10,7 @@
 {%endblock%}
 
 {%block content%}
+<div class="container">
 <form id="partial-correlations-form"
       method="POST"
       action="{{url_for('partial_correlations')}}">
@@ -210,7 +211,8 @@
     <table id="part-corr-results-publish" class="table-hover table-striped cell-border" style="display:none; float: left;">
       <thead>
 	<tr>
-	  <th>_</th>
+	  <th></th>
+	  <th>Index</th>
 	  <th>Record</th>
 	  <th>Phenotype</th>
 	  <th>Authors</th>
@@ -226,7 +228,8 @@
 
       <tbody>
 	<tr class="template-publish-results-row">
-	  <td data-column-heading="_"></td>
+	  <td></td>
+	  <td data-column-heading="Index"></td>
 	  <td data-column-heading="Record"></td>
 	  <td data-column-heading="Phenotype"></td>
 	  <td data-column-heading="Authors"></td>
@@ -249,7 +252,8 @@
     <table id="part-corr-results-geno" style="display:none;">
       <thead>
 	<tr>
-	  <th>_</th>
+	  <th></th>
+	  <th>Index</th>
 	  <th>Locus</th>
 	  <th>Chr</th>
 	  <th>Megabase</th>
@@ -264,7 +268,8 @@
 
       <tbody>
 	<tr class="template-geno-results-row">
-	  <td data-column-heading="_"></td>
+	  <td></td>
+	  <td data-column-heading="Index"></td>
 	  <td data-column-heading="Locus"></td>
 	  <td data-column-heading="Chr"></td>
 	  <td data-column-heading="Megabase"></td>
@@ -286,7 +291,8 @@
     <table id="part-corr-results-probeset" style="display:none;">
       <thead>
 	<tr>
-	  <th>_</th>
+	  <th></th>
+	  <th>Index</th>
 	  <th>Record</th>
 	  <th>Gene ID</th>
 	  <th>Homologene ID</th>
@@ -309,6 +315,8 @@
 
       <tbody>
 	<tr class="template-probeset-results-row">
+	  <td></td>
+	  <td data-column-heading="Index"></td>
 	  <td data-column-heading="_"></td>
 	  <td data-column-heading="Record"></td>
 	  <td data-column-heading="Gene ID"></td>
@@ -333,6 +341,7 @@
   </div>
   <div id="part-corr-error">
   </div>
+</div>
 </div>
 {%endblock%}
 

--- a/wqflask/wqflask/templates/partial_correlations.html
+++ b/wqflask/wqflask/templates/partial_correlations.html
@@ -4,6 +4,9 @@
 
 {%block css%}
 <link rel="stylesheet" type="text/css" href="/static/new/css/partial_correlations.css" />
+<link rel="stylesheet" type="text/css" href="{{ url_for('css', filename='DataTables/css/jquery.dataTables.css') }}" />
+<link rel="stylesheet" type="text/css" href="/static/new/css/trait_list.css" />
+<link rel="stylesheet" type="text/css" href="/static/new/css/show_trait.css" />
 {%endblock%}
 
 {%block content%}
@@ -204,7 +207,7 @@
     <img src="/static/gif/waitAnima2.gif">
   </span>
   <div id="part-corr-success">
-    <table id="part-corr-results-publish" style="display:none;">
+    <table id="part-corr-results-publish" class="table-hover table-striped cell-border" style="display:none; float: left;">
       <thead>
 	<tr>
 	  <th>_</th>
@@ -337,5 +340,7 @@
 {%if step == "select-corr-method":%}
 <script type="text/javascript"
 	src="/static/new/javascript/partial_correlations.js"></script>
+<script language="javascript" type="text/javascript"
+	src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
 {%endif%}
 {%endblock%}


### PR DESCRIPTION
This PR changes the partial correlations result table to match the styling and functionality of other GN2 tables.

This mainly involves using DataTables and probably changing the way the data is passed to the table to avoid redundant code. Instead of having separate tables in the HTML for each data type, this can instead be done using logic in the templating language + DataTables configurations.
