### PR TITLE
Bug/fix hyphen search

### DIFF
--- a/wqflask/wqflask/do_search.py
+++ b/wqflask/wqflask/do_search.py
@@ -137,15 +137,18 @@ class MrnaAssaySearch(DoSearch):
         search_string = escape(self.search_term[0])
 
         if self.search_term[0] != "*":
-            match_clause = """((MATCH (ProbeSet.Name,
+            match_clause = f"""((MATCH (ProbeSet.Name,
                         ProbeSet.description,
                         ProbeSet.symbol,
-                        alias,
                         GenbankId,
                         UniGeneId,
                         Probe_Target_Description)
-                        AGAINST ('%s' IN BOOLEAN MODE))) AND
-                                """ % (search_string)
+                        AGAINST ('{search_string}' IN BOOLEAN MODE)) OR (
+                        alias LIKE '%%; {search_string};%%' OR
+                        alias LIKE '{search_string};%%' OR
+                        alias LIKE '%%; {search_string}' OR
+                        alias LIKE '{search_string}'
+                        )) AND """
         else:
             match_clause = ""
 

--- a/wqflask/wqflask/parser.py
+++ b/wqflask/wqflask/parser.py
@@ -33,7 +33,7 @@ def parse(pstring):
     pstring = re.split(r"""(?:(\w+\s*=\s*[\('"\[][^)'"]*[\)\]'"])  |  # LRS=(1 2 3), cisLRS=[4 5 6], etc
                        (\w+\s*[=:\>\<][\w\*]+)  |  # wiki=bar, GO:foobar, etc
                        (".*?") | ('.*?') | # terms in quotes, i.e. "brain weight"
-                       ([\w\*\?]+))  # shh, brain, etc """, pstring,
+                       ([\w\*\?\-]+))  # shh, brain, etc """, pstring,
                        flags=re.VERBOSE)
 
     pstring = [item.strip() for item in pstring if item and item.strip()]

--- a/wqflask/wqflask/search_results.py
+++ b/wqflask/wqflask/search_results.py
@@ -360,7 +360,8 @@ def get_aliases(symbol_list, species):
 
     filtered_aliases = []
     response = requests.get(
-        GN2_BASE_URL + "/gn3/gene/aliases2/" + symbols_string)
+        GN2_BASE_URL + "gn3/gene/aliases/" + symbols_string)
+
     if response:
         alias_lists = json.loads(response.content)
         seen = set()


### PR DESCRIPTION
This PR should fix a couple issues:
- Hyphens were being treated as separators between search terms, since the regular expression didn't account for them. This has been fixed in fb7035179cb8587c3ae4eaa83a39b06a4e993f8d
- Searches weren't returning results with the search term as an alias correctly. This is for the reasons explained in fadd4e1b679b8d93eb7eabdb9e78633378d673f5

We'll want to keep out for any potentially issues arising as a result of the query change I made, since the way search queries are built can be kind of complicated and there might be some unforeseen issue.