### PR TITLE
Add distinct to fix issue where GeneRIF search returns duplicates

### DIFF
--- a/wqflask/wqflask/do_search.py
+++ b/wqflask/wqflask/do_search.py
@@ -82,7 +82,7 @@ class MrnaAssaySearch(DoSearch):
     DoSearch.search_types['ProbeSet'] = "MrnaAssaySearch"
 
     base_query = """
-                SELECT
+                SELECT DISTINCT
                 ProbeSetFreeze.`Name`,
                 ProbeSetFreeze.`FullName`,
                 ProbeSet.`Name`,


### PR DESCRIPTION
This add DISTINCT for ProbeSet searches, since RIF searches were returning duplicate entries.

It's not clear to me if this wasn't the case in the past, though a couple commits I thought may have been the cause don't seem to have been (undoing them still yields the duplicates issue).
