### PR TITLE
Fix fulltext search for certain searches

### DIFF
--- a/wqflask/wqflask/do_search.py
+++ b/wqflask/wqflask/do_search.py
@@ -1,6 +1,7 @@
-import string
-import requests
 import json
+import re
+import requests
+import string
 
 from flask import Flask, g
 
@@ -137,18 +138,17 @@ class MrnaAssaySearch(DoSearch):
         search_string = escape(self.search_term[0])
 
         if self.search_term[0] != "*":
+            if re.search("\w{1,2}\-\w+|\w+\-\w{1,2}", self.search_term[0]):
+                search_string = f'"{search_string}*"'
+
             match_clause = f"""((MATCH (ProbeSet.Name,
                         ProbeSet.description,
                         ProbeSet.symbol,
+                        alias,
                         GenbankId,
                         UniGeneId,
                         Probe_Target_Description)
-                        AGAINST ('{search_string}' IN BOOLEAN MODE)) OR (
-                        alias LIKE '%%; {search_string};%%' OR
-                        alias LIKE '{search_string};%%' OR
-                        alias LIKE '%%; {search_string}' OR
-                        alias LIKE '{search_string}'
-                        )) AND """
+                        AGAINST ('{search_string}' IN BOOLEAN MODE))) AND """
         else:
             match_clause = ""
 


### PR DESCRIPTION
Hyphens in fulltext searches were causing problems, but a recent commit
I made to fix the issue (6496f75af521d6801c25de682d2852e14d597fed) apparently caused some issues for other types
of searches, in addition to make such searches somewhat slower.

Apparently the issue wasn't just the hyphens, but also the text to
either side of the hyphen being lower than the minimum word length
(which is either 2 or 3 for us, can't remember). To try and address
this, I did a regular expression check for a pattern with text of <3
legnth to either side of a hyphen, and when that's the case I add quotes
from the search term plus an asterisk, which seems to be necessary to
get it to not treat the hyphen as a delimiter and to correctly detect
the search term during a boolean fulltext search.
