### PR TITLE
Add some search tests to check some fulltext searches

### DIFF
--- a/test/requests/search_tests.py
+++ b/test/requests/search_tests.py
@@ -1,0 +1,45 @@
+import requests
+
+searches = [
+    { 
+        "found_text": "1 records were found",
+        "data": {
+            "species": "mouse",
+            "group": "BXD",
+            "type": "Hippocampus mRNA",
+            "dataset": "HC_M2_0606_P",
+            "search_terms_or": "PD-1",
+            "search_terms_and": ""
+        }
+    },
+    { 
+        "found_text": "4 records were found",
+        "data": {
+            "species": "mouse",
+            "group": "BXD",
+            "type": "Hippocampus mRNA",
+            "dataset": "HC_M2_0606_P",
+            "search_terms_or": "Ank-1",
+            "search_terms_and": ""
+        }
+    },
+    { 
+        "found_text": "1017 records were found",
+        "data": {
+            "species": "mouse",
+            "group": "BXD",
+            "type": "Hippocampus mRNA",
+            "dataset": "HC_M2_0606_P",
+            "search_terms_or": "sh*",
+            "search_terms_and": ""
+        }
+    }
+]
+
+def check_fulltext_searches(host):
+    for this_search in searches:
+        result = requests.get(host+"/search", params=this_search["data"])
+        found = result.text.find(this_search["found_text"])
+        assert(found >= 0)
+        assert(result.status_code == 200)
+        print("OK")


### PR DESCRIPTION
This PR adds some search tests, mainly to ensure that the fulltext searches continue to work the same way. It only checks for the correct number of results, but that should be sufficient if done across multiple possible searches.

Not sure how to actually make this test work with the CI, or whether it's even in the right place.