### PR TITLE
Bug/fix qtlreaper snp order

### DIFF
--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -2637,7 +2637,7 @@ class DisplayMappingResults:
                     break
                 m += 1
 
-        if self.manhattan_plot != True:
+        if self.manhattan_plot != True and len(LRSCoordXY) > 1:
             draw_open_polygon(canvas, xy=LRSCoordXY, outline=thisLRSColor,
                               width=lrsEdgeWidth)
 

--- a/wqflask/wqflask/marker_regression/qtlreaper_mapping.py
+++ b/wqflask/wqflask/marker_regression/qtlreaper_mapping.py
@@ -183,7 +183,16 @@ def natural_sort(marker_list):
     Function to naturally sort numbers + strings, adopted from user Mark Byers here: https://stackoverflow.com/questions/4836710/does-python-have-a-built-in-function-for-string-natural-sort
     Changed to return indices instead of values, though, since the same reordering needs to be applied to bootstrap results
     """
-    convert = lambda text: int(text) if text.isdigit() else text.lower()
+
+    def convert(text):
+        if text.isdigit():
+            return int(text)
+        else:
+            if text != "M":
+                return text.lower()
+            else:
+                return "z"
+
     alphanum_key = lambda key: [convert(c) for c in re.split(
         '([0-9]+)', str(marker_list[key]['chr']))]
     return sorted(list(range(len(marker_list))), key=alphanum_key)


### PR DESCRIPTION
This fixes a couple issues that were causing qtlreaper to not work on the DOL (Diversity Outbred Lung) genotypes.

- For some reason the new qtlreaper was sorting chromosome alphabetically, so I addressed this in a previous commit by sorting them using an algorithm that sorted numbers followed by alphabetical letters. But this caused issues with the introduction of "M" as a "chromosome" - it's last in the genotype file, but wasn't being sorted last by the sort algorithm. So as a kind of awkward fix, I made the sort algorithm treat "M" as "Z" (making it always be last)
- Doing interval mapping would cause and error if there was only one marker for a chromosome (since when drawing the figure it links individual markers with one another within each chromosome). I changed it to ignore edge cases where there's only a single marker on a chromosome.
