### PR TITLE
Fix issues that prevented genotype traits from being added to collect…

### DIFF
--- a/wqflask/base/trait.py
+++ b/wqflask/base/trait.py
@@ -94,6 +94,7 @@ class GeneralTrait:
         self.num_overlap = None
         self.strand_probe = None
         self.symbol = None
+        self.abbreviation = None
         self.display_name = self.name
 
         self.LRS_score_repr = "N/A"

--- a/wqflask/wqflask/collect.py
+++ b/wqflask/wqflask/collect.py
@@ -200,18 +200,33 @@ def trait_info_str(trait):
         return (trt.symbol or trt.abbreviation or "N/A")[:20]
 
     def __lrs(trt):
-        return (
-            f"{float(trait.LRS_score_repr):0.3f}" if float(trait.LRS_score_repr) > 0
-            else f"{trait.LRS_score_repr}")
+        if trait.dataset.type == "Geno":
+            return 0
+        else:
+            return (
+                f"{float(trait.LRS_score_repr):0.3f}" if float(trait.LRS_score_repr) > 0
+                else f"{trait.LRS_score_repr}")
+
+    def __lrs_location(trt):
+        if hasattr(trt, "LRS_location_repr"):
+            return trt.LRS_location_repr
+        else:
+            return "N/A"
 
     def __location(trt):
         if hasattr(trt, "location_repr"):
             return trt.location_repr
         return None
 
+    def __mean(trt):
+        if trait.mean:
+            return trt.mean
+        else:
+            return 0
+
     return "{}|||{}|||{}|||{}|||{}|||{:0.3f}|||{}|||{}".format(
         trait.name, trait.dataset.name, __trait_desc(trait), __symbol(trait),
-        __location(trait), trait.mean, __lrs(trait), trait.LRS_location_repr)
+        __location(trait), __mean(trait), __lrs(trait), __lrs_location(trait))
 
 @app.route("/collections/view")
 def view_collection():


### PR DESCRIPTION
There were some errors when adding genotypes to a collection.

Most were related to the "trait_info_str" function in collect.py - I think that this was just written while overlooking genotype traits (which is understandable, since they're usually not used when testing). To get things working again I had it set some default values of "N/A" or 0, just to prevent the error. Ideally this function probably shouldn't be necessary, since there's many other functions that involve passing around lists of traits and do so in the same way (which can be improved if necessary, but they should all be using the same code).