### PR TITLE
Fix Spearman Rank correlation appearing as 'r' instead of 'rho'

### DIFF
--- a/wqflask/wqflask/static/new/javascript/draw_corr_scatterplot.js
+++ b/wqflask/wqflask/static/new/javascript/draw_corr_scatterplot.js
@@ -108,7 +108,7 @@ var sr_layout = {
     xanchor: 'right',
     y: 1.05,
     yanchor: 'top',
-    text: '<i>r</i> = ' + js_data.srr_value.toFixed(3) + ', <i>P</i> = ' + js_data.srp_value.toExponential(3) + ', <i>n</i> = ' + js_data.num_overlap,
+    text: '<i>rho</i> = ' + js_data.srr_value.toFixed(3) + ', <i>P</i> = ' + js_data.srp_value.toExponential(3) + ', <i>n</i> = ' + js_data.num_overlap,
     showarrow: false,
     font: {
       size: 14


### PR DESCRIPTION
This is a simple minor fix change "r" to "rho" in the legend for Spearman Rank correlation scatterplots.