### PR TITLE
Add scatterplot link for additive effect in mapping results

### DIFF
--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -305,7 +305,11 @@
                   {% endif %}
                   <td align="right">{{ marker.display_pos }}</td>
                   {% if 'additive' in marker %}
+                  {% if geno_db_exists == "True" %}
+                  <td align="right"><a target"_blank" href="corr_scatter_plot?method=pearson&dataset_1={{ dataset.group.name }}Geno&dataset_2={{ dataset.name }}&trait_1={{ marker.name }}&trait_2={{ this_trait.name }}">{{ '%0.3f' | format(marker.additive|float) }}</a></td>
+                  {% else %}}
                   <td align="right">{{ '%0.3f' | format(marker.additive|float) }}</td>
+                  {% endif %}
                   {% endif %}
                   {% if 'dominance' in marker and dataset.group.genetic_type != "riset" %}
                   <td align="right">{{ '%0.2f' | format(marker.dominance|float) }}</td>


### PR DESCRIPTION
This adds scatterplot links for the additive effect values in mapping results. This is just a scatterplot between the mapped phenotype and the databased marker in question (the link is only displayed if genotypes are databased).
