### PR TITLE
Replace references of "publish_xref.pubmed_id" with "publication.id"

### DIFF
--- a/wqflask/wqflask/metadata_edits.py
+++ b/wqflask/wqflask/metadata_edits.py
@@ -130,7 +130,7 @@ def edit_phenotype(conn, name, dataset_id):
                                 data_.get("new"),
                                 "\n".join(
                                     difflib.ndiff(
-                                        [data_.get("old")], [data_.get("new")]
+                                        [data_.get("old") or ""], [data_.get("new")]
                                     )
                                 ),
                             ),
@@ -357,6 +357,7 @@ def update_phenotype(dataset_id: str, name: str):
             }
         )
     publication_ = {
+        "pubmed_id": data_.get("pubmed-id"),
         "abstract": data_.get("abstract"),
         "authors": data_.get("authors"),
         "title": data_.get("title"),
@@ -373,7 +374,7 @@ def update_phenotype(dataset_id: str, name: str):
             "Publication",
             data=Publication(**publication_),
             where=Publication(
-                id_=data_.get("pubmed-id", data_.get("old_id_"))
+                id_=data_.get("old_id_")
             ),
         )
     if updated_publications:

--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -81,8 +81,8 @@
                 Description will be ignored.  Do not enter any non-digit
                 character in this field. -->
             <div class="col-sm-7 col-lg-8">
-                <textarea name="pubmed-id" class="form-control" rows="1">{{ publish_xref.publication_id |default('', true) }}</textarea>
-                <input name="old_id_" class="changed" type="hidden" value="{{ publish_xref.publication_id |default('', true) }}"/>
+                <textarea name="pubmed-id" class="form-control" rows="1">{{ publication.pubmed_id |default('', true) }}</textarea>
+		<input name="old_id_" class="changed" type="hidden" value="{{ publication.id_ |default('', true) }}"/>
             </div>
         </div>
         <div class="form-group">


### PR DESCRIPTION
See: https://issues.genenetwork.org/issues/edit-metadata-bugs.html

* wqflask/wqflask/metadata_edits (edit_phenotype):
When diffing, should there be a null, use a ""
during page display. Also, use the
"publication.id_" instead of
"publication.pubmed_id" when updating a
publication.
* wqflask/wqflask/templates/edit_phenotype.html:
In the HTML form, use values of "publication"
instead of "publish_xref" when referring to a
publication.
