### PR TITLE
UI/improvements to data uploader

### DIFF
--- a/wqflask/wqflask/templates/edit_history.html
+++ b/wqflask/wqflask/templates/edit_history.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+{% block title %}Trait Submission{% endblock %}
+
+{% block css %}
+<link rel="stylesheet" type="text/css" href="{{ url_for('css', filename='DataTables/css/jquery.dataTables.css') }}" />
+{% endblock %}
+
+{% block content %}
+<!-- Start of body -->
+<div class="container">
+
+    <h1>Edit history: {{}}</h1>
+    {% if diff %}
+    <div class="row">
+	<table id="history" class="table-responsive table-hover table-striped cell-border">
+            <tbody>
+		<tr>
+                    <th>Timestamp</th>
+                    <th>Editor</th>
+                    <th>Field</th>
+                    <th>Diff</th>
+		</tr>
+		{% set ns = namespace(display_cell=True) %}
+
+		{% for timestamp, group in diff %}
+		{% set ns.display_cell = True %}
+		{% for i in group %}
+		<tr>
+                    {% if ns.display_cell and i.timestamp == timestamp %}
+
+                    {% set author = i.author %}
+                    {% set timestamp_ = i.timestamp %}
+
+                    {% else %}
+
+                    {% set author = "" %}
+                    {% set timestamp_ = "" %}
+
+                    {% endif %}
+                    <td>{{ timestamp_ }}</td>
+		    <td>{{ author }}</td>
+		    <td>{{ i.diff.field }}</td>
+		    <td><pre>{{ i.diff.diff }}</pre></td>
+		    {% set ns.display_cell = False %}
+		</tr>
+		{% endfor %}
+		{% endfor %}
+	    </tbody>
+	</table>
+    </div>
+
+    {% endif %}
+
+</div>
+{%endblock%}
+
+{% block js %}
+<script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.js') }}"></script>
+<script language="javascript" type="text/javascript" src="{{ url_for('js', filename='DataTables/js/jquery.dataTables.min.js') }}"></script>
+<script language="javascript" type="text/javascript">
+ gn_server_url = "{{ gn_server_url }}";
+
+ $(document).ready( function() {
+     $('#history').dataTable();
+ });
+</script>
+{% endblock %}

--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -77,7 +77,7 @@
             <label for="pubmed-id" class="col-sm-3 col-lg-2 control-label text-left">PubMed ID</label>
             <!-- Do not enter PubMed_ID if this trait has not been Published.
                 If the PubMed_ID you entered is alreday stored in our
-                database, all the following fields except Post Publication
+                database, all the following fields except Postpublication
                 Description will be ignored.  Do not enter any non-digit
                 character in this field. -->
             <div class="col-sm-7 col-lg-8">
@@ -86,18 +86,18 @@
             </div>
         </div>
         <div class="form-group">
-            <label for="pre-pub-desc" class="col-sm-3 col-lg-2 control-label text-left">Pre Publication Description</label>
+            <label for="pre-pub-desc" class="col-sm-3 col-lg-2 control-label text-left">Prepublication Description</label>
             <div class="col-sm-7 col-lg-8">
                 <textarea name="pre-pub-desc" class="form-control" rows="4">{{ phenotype.pre_pub_description |default('', true) }}</textarea>
                 <input name="old_pre_pub_description" class="changed" type="hidden" value="{{ phenotype.pre_pub_description |default('', true) }}"/>
             </div>
-            <!-- If the PubMed ID is entered, the Post Publication Description
+            <!-- If the PubMed ID is entered, the Postpublication Description
                 will be shown to all users. If there is no PubMed ID, and the
-                Pre Publication Description is entered, only you and
-                authorized users can see the Post Publication Description -->
+                Prepublication Description is entered, only you and
+                authorized users can see the Postpublication Description -->
         </div>
         <div class="form-group">
-            <label for="post-pub-desc" class="col-sm-3 col-lg-2 control-label text-left">Post Publication Description</label>
+            <label for="post-pub-desc" class="col-sm-3 col-lg-2 control-label text-left">Postpublication Description</label>
             <div class="col-sm-7 col-lg-8">
                 <textarea name="post-pub-desc" class="form-control" rows="4">{{ phenotype.post_pub_description |default('', true) }}</textarea>
                 <input name="old_post_pub_description" class="changed" type="hidden" value="{{ phenotype.post_pub_description |default('', true) }}"/>
@@ -119,7 +119,7 @@
         </div>
         <div class="form-group">
             <label for="pre-pub-abbrev" class="col-sm-3 col-lg-2 control-label text-left">
-                Pre Publication Abbreviation
+                Prepublication Abbreviation
             </label>
             <div class="col-sm-7 col-lg-8">
                 <textarea name="pre-pub-abbrev" class="form-control" rows="1">{{ phenotype.pre_pub_abbreviation |default('', true) }}</textarea>
@@ -128,7 +128,7 @@
         </div>
         <div class="form-group">
             <label for="post-pub-abbrev" class="col-sm-3 col-lg-2 control-label text-left">
-                Post Publication Abbreviation
+                Postpublication Abbreviation
             </label>
             <div class="col-sm-7 col-lg-8">
                 <textarea name="post-pub-abbrev" class="form-control" rows="1">{{ phenotype.post_pub_abbreviation |default('', true) }}</textarea>

--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -14,6 +14,7 @@
 <div class="container">
     <div class="page-header text-left">
         <h1>Trait Metadata and Data Editing Form</h1>
+        <small><a href="{{url_for('metadata_edit.show_history', dataset_id=dataset_id, name=name)}}" target="_blank">[View History]</a></small>
     </div>
 
     {% if diff %}

--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -175,8 +175,22 @@
                 <textarea name="authors" class="form-control" rows="3" placeholder="Example: Roy S, Ingels J, Bohl CJ, McCarty M, Lu L, Mulligan MK, Mozhui K, Centeno A, Williams EG, Auwerx J, Williams RW">{{ publication.authors |default('', true) }}</textarea>
                 <input name="old_authors" class="changed" type="hidden" value="{{ publication.authors |default('', true) }}"/>
             </div>
-        </div>
-        <div class="form-group">
+	</div>
+	<div class="form-group">
+            <label for="year" class="col-sm-3 col-lg-2 control-label text-left">Year</label>
+            <div class="col-sm-7 col-lg-8">
+                <textarea name="year" class="form-control" rows="1">{{ publication.year |default('', true) }}</textarea>
+                <input name="old_year" class="changed" type="hidden" value="{{ publication.year |default('', true) }}"/>
+            </div>
+	</div>
+	<div class="form-group">
+            <label for="month" class="col-sm-3 col-lg-2 control-label text-left">Month</label>
+            <div class="col-sm-7 col-lg-8">
+                <textarea name="month" class="form-control" rows="1">{{ publication.month |default('', true) }}</textarea>
+                <input name="old_month" class="changed" type="hidden" value="{{ publication.month |default('', true) }}"/>
+            </div>
+	</div>
+	<div class="form-group">
             <label for="title" class="col-sm-3 col-lg-2 control-label text-left">Title</label>
             <div class="col-sm-7 col-lg-8">
                 <textarea name="title" class="form-control" rows="2">{{ publication.title |default('', true) }}</textarea>
@@ -209,20 +223,6 @@
             <div class="col-sm-7 col-lg-8">
                 <textarea name="pages" class="form-control" rows="1">{{ publication.pages |default('', true) }}</textarea>
                 <input name="old_pages" class="changed" type="hidden" value="{{ publication.pages |default('', true) }}"/>
-            </div>
-        </div>
-        <div class="form-group">
-            <label for="month" class="col-sm-3 col-lg-2 control-label text-left">Month</label>
-            <div class="col-sm-7 col-lg-8">
-                <textarea name="month" class="form-control" rows="1">{{ publication.month |default('', true) }}</textarea>
-                <input name="old_month" class="changed" type="hidden" value="{{ publication.month |default('', true) }}"/>
-            </div>
-        </div>
-        <div class="form-group">
-            <label for="year" class="col-sm-3 col-lg-2 control-label text-left">Year</label>
-            <div class="col-sm-7 col-lg-8">
-                <textarea name="year" class="form-control" rows="1">{{ publication.year |default('', true) }}</textarea>
-                <input name="old_year" class="changed" type="hidden" value="{{ publication.year |default('', true) }}"/>
             </div>
         </div>
         <div style="margin-left: 13%;">

--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -193,7 +193,7 @@
 	<div class="form-group">
             <label for="volume" class="col-sm-3 col-lg-2 control-label text-left">Volume</label>
             <div class="col-sm-7 col-lg-8">
-                <textarea name="volume" class="form-control" rows="6">{{ publication.volume |default('', true) }}</textarea>
+                <textarea name="volume" class="form-control" rows="1">{{ publication.volume |default('', true) }}</textarea>
                 <input name="old_volume" class="changed" type="hidden" value="{{ publication.volume |default('', true) }}"/>
             </div>
 	</div>

--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -65,7 +65,7 @@
     {% endif %}
     <form id="edit-form" class="container form-horizontal" method="post" action="/datasets/{{dataset_id}}/traits/{{ publish_xref.id_ }}?resource-id={{ resource_id }}" enctype='multipart/form-data'>
 	<div class="form-group">
-	    <div class="controls center-block" style="width: max-content;">
+	    <div class="controls left-block col-sm-8 col-lg-8" style="width: max-content;">
 		<input name="inbred-set-id" class="changed" type="hidden" value="{{ publish_xref.inbred_set_id }}"/>
 		<input name="phenotype-id" class="changed" type="hidden" value="{{ publish_xref.phenotype_id }}"/>
 		<input name="comments" class="changed" type="hidden" value="{{ publish_xref.comments }}"/>
@@ -224,7 +224,7 @@
                 <input name="old_pages" class="changed" type="hidden" value="{{ publication.pages |default('', true) }}"/>
             </div>
         </div>
-        <div style="margin-left: 13%;">
+        <div>
             <a href="/datasets/{{ publish_xref.id_ }}/traits/{{ publish_xref.phenotype_id }}/csv?resource-id={{ resource_id }}" class="btn btn-link btn-sm">
                 Click to Download CSV Sample Data
             </a>
@@ -237,14 +237,12 @@
                 Note: Current allowable case-attributes are: {{ ', '.join(headers) }}.
 		<a href="{{url_for('metadata_edit.show_case_attribute_columns')}}" target="_blank">You can find these case-attribute  descriptions here.</a>
             </p>
-        </div>
-	<div class="form-group">
-	    <div class="controls center-block" style="width: max-content;">
-		<input name="inbred-set-id" class="changed" type="hidden" value="{{ publish_xref.inbred_set_id }}"/>
-		<input name="phenotype-id" class="changed" type="hidden" value="{{ publish_xref.phenotype_id }}"/>
-		<input name="comments" class="changed" type="hidden" value="{{ publish_xref.comments }}"/>
+	</div>
+
+	<div class="form-group col-xs-7">
+	    <div class="controls left-block col-sm-8 col-lg-8" style="width: max-content;">
 		<input type="submit" style="width: 125px; margin-right: 25px;" class="btn btn-success form-control col-xs-2 changed" value="Submit Change">
-            </div>
+	    </div>
 	</div>
     </form>
 </div>

--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -70,7 +70,6 @@
 		<input name="phenotype-id" class="changed" type="hidden" value="{{ publish_xref.phenotype_id }}"/>
 		<input name="comments" class="changed" type="hidden" value="{{ publish_xref.comments }}"/>
 		<input type="submit" style="width: 125px; margin-right: 25px;" class="btn btn-success form-control col-xs-2 changed" value="Submit Change">
-		<input type="reset" style="width: 110px;" class="btn btn-danger form-control col-xs-2 changed" onClick="window.location.reload();" value="Reset">
             </div>
 	</div>
         <div class="form-group">
@@ -245,7 +244,6 @@
 		<input name="phenotype-id" class="changed" type="hidden" value="{{ publish_xref.phenotype_id }}"/>
 		<input name="comments" class="changed" type="hidden" value="{{ publish_xref.comments }}"/>
 		<input type="submit" style="width: 125px; margin-right: 25px;" class="btn btn-success form-control col-xs-2 changed" value="Submit Change">
-		<input type="reset" style="width: 110px;" class="btn btn-danger form-control col-xs-2 changed" onClick="window.location.reload();" value="Reset">
             </div>
 	</div>
     </form>

--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -172,7 +172,7 @@
         <div class="form-group">
             <label for="authors" class="col-sm-3 col-lg-2 control-label text-left">Authors</label>
             <div class="col-sm-7 col-lg-8">
-                <textarea name="authors" class="form-control" rows="2" placeholder="Example: Roy S, Ingels J, Bohl CJ, McCarty M, Lu L, Mulligan MK, Mozhui K, Centeno A, Williams EG, Auwerx J, Williams RW">{{ publication.authors |default('', true) }}</textarea>
+                <textarea name="authors" class="form-control" rows="3" placeholder="Example: Roy S, Ingels J, Bohl CJ, McCarty M, Lu L, Mulligan MK, Mozhui K, Centeno A, Williams EG, Auwerx J, Williams RW">{{ publication.authors |default('', true) }}</textarea>
                 <input name="old_authors" class="changed" type="hidden" value="{{ publication.authors |default('', true) }}"/>
             </div>
         </div>

--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -225,13 +225,6 @@
                 <input name="old_year" class="changed" type="hidden" value="{{ publication.year |default('', true) }}"/>
             </div>
         </div>
-        <div class="form-group">
-            <label for="sequence" class="col-sm-3 col-lg-2 control-label text-left">Sequence</label>
-            <div class="col-sm-7 col-lg-8">
-                <textarea name="sequence" class="form-control" rows="6">{{ publish_xref.sequence |default('', true) }}</textarea>
-                <input name="old_sequence" class="changed" type="hidden" value="{{ publication.sequence |default('', true) }}"/>
-            </div>
-        </div>
         <div style="margin-left: 13%;">
             <a href="/datasets/{{ publish_xref.id_ }}/traits/{{ publish_xref.phenotype_id }}/csv?resource-id={{ resource_id }}" class="btn btn-link btn-sm">
                 Click to Download CSV Sample Data

--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -13,7 +13,7 @@
 {% endwith %}
 <div class="container">
     <div class="page-header text-left">
-        <h1>Trait Metadata and Data Editing Form</h1>
+        <h1>Trait Metadata and Data Editing Form: {{ name }}</h1>
         <small><a href="{{url_for('metadata_edit.show_history', dataset_id=dataset_id, name=name)}}" target="_blank">[View History]</a></small>
     </div>
 


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->
This PR adds some UI tweaks on the data uploader page as discussed `[here](https://issues.genenetwork.org/issues/edit-metadata-bugs.html)`. Changes:
  - [X] Fix Typos
  - [X] Remove some form fields (Sequence)
  - [X] Adjust the size of some form fields
  - [X] Remove the "Reset" button
  - [X] Move the update history to it's own page
  - [X] Re-order form fields to match common citation styles
  - [-] Re-design the button for uploading the forms

I'll re-design the button for uploading the forms in tandem with re-working the logic for uploading the case-attributes.