### PR TITLE
templates: base: Update GN2 footer

### DIFF
--- a/wqflask/wqflask/templates/base.html
+++ b/wqflask/wqflask/templates/base.html
@@ -213,7 +213,7 @@
                     <a href="http://joss.theoj.org/papers/10.21105/joss.00025"><img src="https://camo.githubusercontent.com/846b750f582ae8f1d0b4f7e8fee78bed705c88ba/687474703a2f2f6a6f73732e7468656f6a2e6f72672f7061706572732f31302e32313130352f6a6f73732e30303032352f7374617475732e737667" alt="JOSS" data-canonical-src="http://joss.theoj.org/papers/10.21105/joss.00025/status.svg" style="max-width:100%;"></a>
             </p>
             <p>
-            Development and source code on <a href="https://github.com/genenetwork/">github</a> with <a href="https://github.com/genenetwork/genenetwork2/issues">issue tracker</a> and <a href="https://github.com/genenetwork/genenetwork2/blob/master/README.md">documentation</a>. Join the <span class="broken_link" href="http://listserv.uthsc.edu/mailman/listinfo/genenetwork-dev">mailing list</span> and find us on <a href="https://webchat.freenode.net#genenetwork">IRC</a> (#genenetwork channel).
+		Development and source code on <a href="https://github.com/genenetwork/">github</a> with <a href="https://issues.genenetwork.org/">issue tracker</a> and <a href="https://github.com/genenetwork/genenetwork2/blob/master/README.md">documentation</a>.
             {% if version: %}
             <p><small>GeneNetwork {{ version }}</small></p>
             {% endif %}


### PR DESCRIPTION
This PR updates the footer based on: https://github.com/genenetwork/genenetwork2/pull/709. The aforementioned PR couldn't be merged because of merge conflicts.