### PR TITLE
Chore/GN2 Clean up

### DIFF
--- a/wqflask/runserver.py
+++ b/wqflask/runserver.py
@@ -23,9 +23,7 @@ app_config()
 werkzeug_logger = logging.getLogger('werkzeug')
 
 if WEBSERVER_MODE == 'DEBUG':
-    from flask_debugtoolbar import DebugToolbarExtension
     app.debug = True
-    toolbar = DebugToolbarExtension(app)
     app.run(host='0.0.0.0',
             port=SERVER_PORT,
             debug=True,

--- a/wqflask/utility/startup_config.py
+++ b/wqflask/utility/startup_config.py
@@ -23,12 +23,9 @@ def app_config():
     if mode in ["DEV", "DEBUG"]:
         app.config['TEMPLATES_AUTO_RELOAD'] = True
         if mode == "DEBUG":
-            from flask_debugtoolbar import DebugToolbarExtension
             app.debug = True
-            toolbar = DebugToolbarExtension(app)
 
     print("==========================================")
-
     show_settings()
 
     port = get_setting_int("SERVER_PORT")

--- a/wqflask/wqflask/metadata_edits.py
+++ b/wqflask/wqflask/metadata_edits.py
@@ -62,13 +62,16 @@ def _get_diffs(
 ):
     def __get_file_metadata(file_name: str) -> Dict:
         author, resource_id, time_stamp, *_ = file_name.split(".")
-
+        try:
+            author = json.loads(redis_conn.hget("users", author)).get(
+               "full_name"
+           )
+        except (AttributeError, TypeError):
+            author = author
         return {
             "resource_id": resource_id,
             "file_name": file_name,
-            "author": json.loads(redis_conn.hget("users", author)).get(
-                "full_name"
-            ),
+            "author": author,
             "time_stamp": time_stamp,
             "roles": get_highest_user_access_role(
                 resource_id=resource_id,

--- a/wqflask/wqflask/metadata_edits.py
+++ b/wqflask/wqflask/metadata_edits.py
@@ -227,8 +227,7 @@ def update_phenotype(dataset_id: str, name: str):
         diff_data = {}
         with database_connection() as conn:
             headers = ["Strain Name", "Value", "SE", "Count"] + list(
-                get_case_attributes(conn).keys()
-            )
+                map(lambda x: x[1], get_case_attributes(conn)))
             diff_data = remove_insignificant_edits(
                 diff_data=csv_diff(
                     base_csv=(


### PR DESCRIPTION
#### Description
This PR:
- Removes FlaskDebugToolbar.  It's utility is already provided natively in Python's pudb module. @fredmanglis @Alexanderlacuna and @zsloan take note.  Eventually, I'll remove this as an input in gn2's definition in our channel.
- Uses new function signature when fetching case-attributes.
- Fix edge-case when listing diffs if a user who edits a file does not exist in Redis.  This should never happen, but nevertheless, I catered for it.