### PR TITLE
Feature/add support for db transactions

### DIFF
--- a/wqflask/wqflask/database.py
+++ b/wqflask/wqflask/database.py
@@ -8,16 +8,6 @@ import importlib
 
 import MySQLdb
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.ext.declarative import declarative_base
-
-def read_from_pyfile(pyfile, setting):
-    orig_sys_path = sys.path[:]
-    sys.path.insert(0, os.path.dirname(pyfile))
-    module = importlib.import_module(os.path.basename(pyfile).strip(".py"))
-    sys.path = orig_sys_path[:]
-    return module.__dict__.get(setting)
 
 def sql_uri():
     """Read the SQL_URI from the environment or settings file."""


### PR DESCRIPTION
#### Description

This PR enables GN2 to support roll-backs should anything wrong happen within a connection context (as opposed to the cursor context).  For an overview of how context managers - the inspiration behind this PR - please look at: <https://www.youtube.com/watch?v=ucGpcA9r4hU>

To control roll-backs, we need to:
- set autocommit=0
- have a table whose engine supports transactions .E.g. innodb.  ATM, GN2 uses MyISAM which is a relic of the past.

Regardless of what engine we use, this PR has no bad side-effect and there's no code changes else where that's required.

#### How should this be tested?
<!-- What should you do to test this PR? Is there any manual quality
assurance checks that should be done. What are the expectations -->

Example usage:
Assuming InnoDB:

```
with database_connection() as conn:
    with conn.cursor() as cursor:
        cursor.execute(
            """
INSERT INTO CaseAttribute (Name, Description) VALUES (%s, %s)
            """, ("Test", "Random Description")
        )
        print(cursor.fetchall())
        print(0/0)

```
The above query will be rolled back.  On MyISAM and other db engines that don't have transactional support, the above will still be executed and "connection.rollback()" will be silently ignored.