### PR TITLE
Close a database connection only once

### DIFF
--- a/wqflask/wqflask/database.py
+++ b/wqflask/wqflask/database.py
@@ -44,7 +44,6 @@ def database_connection():
     )
     try:
         yield connection
-        connection.close()
     except Exception:
         connection.rollback()
         raise


### PR DESCRIPTION
Close a database connection only once, otherwise while attempting to close an already closed connection, an exception will be raised.