### PR TITLE
Correlations: Select top `n` results at the very end

### DIFF
--- a/wqflask/wqflask/correlation/rust_correlation.py
+++ b/wqflask/wqflask/correlation/rust_correlation.py
@@ -229,7 +229,7 @@ def merge_results(dict_a: dict, dict_b: dict, dict_c: dict) -> list[dict]:
 
 
 def __compute_sample_corr__(
-        start_vars: dict, corr_type: str, method: str, n_top: int,
+        start_vars: dict, corr_type: str, method: str,
         target_trait_info: tuple):
     """Compute the sample correlations"""
     (this_dataset, this_trait, target_dataset, sample_data) = target_trait_info
@@ -256,14 +256,14 @@ def __compute_sample_corr__(
                 (sample_vals, target_data) = read_text_file(
                     sample_data, file_path)
                 return run_correlation(target_data, sample_vals,
-                                       method, ",", corr_type, n_top)
+                                       method, ",", corr_type)
             write_db_to_textfile(target_dataset.name, conn)
             file_path = fetch_text_file(target_dataset.name, conn)
             if file_path:
                 (sample_vals, target_data) = read_text_file(
                     sample_data, file_path)
                 return run_correlation(target_data, sample_vals,
-                                       method, ",", corr_type, n_top)
+                                       method, ",", corr_type)
 
     target_dataset.get_trait_data(list(sample_data.keys()))
 
@@ -280,8 +280,7 @@ def __compute_sample_corr__(
         return {}
 
     return run_correlation(
-        target_data, list(sample_data.values()), method, ",", corr_type,
-        n_top)
+        target_data, list(sample_data.values()), method, ",", corr_type)
 
 
 def __datasets_compatible_p__(trait_dataset, target_dataset, corr_method):
@@ -292,7 +291,7 @@ def __datasets_compatible_p__(trait_dataset, target_dataset, corr_method):
 
 
 def __compute_tissue_corr__(
-        start_vars: dict, corr_type: str, method: str, n_top: int,
+        start_vars: dict, corr_type: str, method: str,
         target_trait_info: tuple):
     """Compute the tissue correlations"""
     (this_dataset, this_trait, target_dataset, sample_data) = target_trait_info
@@ -316,7 +315,7 @@ def __compute_tissue_corr__(
 
 
 def __compute_lit_corr__(
-        start_vars: dict, corr_type: str, method: str, n_top: int,
+        start_vars: dict, corr_type: str, method: str,
         target_trait_info: tuple):
     """Compute the literature correlations"""
     (this_dataset, this_trait, target_dataset, sample_data) = target_trait_info
@@ -333,7 +332,7 @@ def __compute_lit_corr__(
             lambda acc, lit: {**acc, **lit},
             compute_all_lit_correlation(
                 conn=conn, trait_lists=list(geneid_dict.items()),
-                species=species, gene_id=this_trait_geneid)[:n_top],
+                species=species, gene_id=this_trait_geneid),
             {})
     return {}
 

--- a/wqflask/wqflask/correlation/show_corr_results.py
+++ b/wqflask/wqflask/correlation/show_corr_results.py
@@ -63,7 +63,8 @@ def set_template_vars(start_vars, correlation_data):
     correlation_data['formatted_corr_type'] = get_formatted_corr_type(
         corr_type, corr_method)
 
-    return correlation_data
+    top_n = int(start_vars.get("corr_return_results", 500))
+    return correlation_data[0:top_n]
 
 
 def apply_filters(trait, target_trait, target_dataset, **filters):


### PR DESCRIPTION
Filter the correlation results before selecting the top `n` results to avoid the scenario where less than `n` results are returned.

* wqflask/wqflask/correlation/rust_correlation.py: remove `top_n` and `n_top` arguments from function no longer needing them.
* wqflask/wqflask/correlation/show_corr_results.py: Select top `n` results at the very end, at output.

This pull request relies on [this other pull request](https://github.com/genenetwork/genenetwork3/pull/105)