### PR TITLE
bugfix

### DIFF
--- a/wqflask/wqflask/correlation/rust_correlation.py
+++ b/wqflask/wqflask/correlation/rust_correlation.py
@@ -268,7 +268,7 @@ def __compute_sample_corr__(
     target_dataset.get_trait_data(list(sample_data.keys()))
 
     def __merge_key_and_values__(rows, current):
-        wo_nones = [value for value in current[1] if value is not None]
+        wo_nones = [value for value in current[1]]
         if len(wo_nones) > 0:
             return rows + [[current[0]] + wo_nones]
         return rows


### PR DESCRIPTION
* this stage is already handled by the rust code  hence doing positional comparison lead to different results than expected
* this is necessary to make sure that the number of items in each row to the number of the x_vals
* a positional comparison is done on the rust code is done to remove nan values
```
//for example
x_vals  = [1.21,1.131,121.11[
y_vals = [Nan,1.1,1.2]
//
parsed_x_val = [1.131,121.11]
parsed_y_val= [1.1,1.2]

```