### PR TITLE
Remove check for shortnames/fullnames in probeset metadata query

### DIFF
--- a/wqflask/base/data_set/dataset.py
+++ b/wqflask/base/data_set/dataset.py
@@ -94,9 +94,8 @@ class DataSet:
                 __accession_id_dict, = itertools.islice(
                     query_sql(conn,
                         ("SELECT InfoFiles.GN_AccesionId AS accession_id "
-                        f"FROM InfoFiles WHERE InfoFiles.InfoPageName = '{conn.escape_string(self.name).decode()}' "
-                        f"AND InfoFiles.DB_Name = '{conn.escape_string(self.fullname).decode()}' "
-                        f"OR InfoFiles.DB_Name = '{conn.escape_string(self.shortname).decode()}'")
+                        "FROM InfoFiles WHERE InfoFiles.InfoPageName = "
+                         f"'{conn.escape_string(self.name).decode()}'")
                     ), 1)
             else:  # The Value passed is not present
                 raise LookupError


### PR DESCRIPTION
The InfoFiles tables has 2 unique constraints:

```
SELECT DISTINCT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS WHERE table_name = 'InfoFiles' and constraint_type = 'UNIQUE';
```
which results in:

```
InfoPageName
GN_AccesionId
```
However, shortname/fullname can have NULL values thereby producing errors in some pages that display the probeset data.