### PR TITLE
Use a dataset's name to fetch it's metadata

### DIFF
--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -490,23 +490,21 @@ def show_trait_page():
         template_vars.js_data = json.dumps(template_vars.js_data,
                                            default=json_default_handler,
                                            indent="   ")
-
+        # Should there be any mis-configurations, things will still
+        # work.
+        metadata = {}
         try:
-            metadata = (
-                template_vars.dataset.accession_id
-                .bind(
-                    lambda idx: requests.get(
-                        urljoin(
-                            GN3_LOCAL_URL,
-                            f"/api/metadata/dataset/GN{idx}")
-                    )
-                )
+            metadata = requests.get(
+                urljoin(
+                    GN3_LOCAL_URL,
+                    f"/api/metadata/dataset/{request.args.get('dataset')}")
             ).json()
         except:
             metadata = {}
-
-        return render_template("show_trait.html",
-                               metadata=metadata, **template_vars.__dict__)
+        return render_template(
+            "show_trait.html",
+            metadata=metadata,
+            **template_vars.__dict__)
 
 
 @app.route("/heatmap", methods=('POST',))


### PR DESCRIPTION
Use a dataset's name to fetch metadata.  Related to: https://github.com/genenetwork/genenetwork3/pull/108