### PR TITLE
Feature/add mapping link

### DIFF
--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -88,7 +88,6 @@ ARIAL_FILE = "./wqflask/static/fonts/arial.ttf"
 
 assert(os.path.isfile(VERDANA_FILE))
 
-
 class HtmlGenWrapper:
     """Wrapper Methods for HTML gen"""
     @staticmethod
@@ -244,6 +243,7 @@ class DisplayMappingResults:
 
     def __init__(self, start_vars):
         self.temp_uuid = start_vars['temp_uuid']
+        self.hash_of_inputs = start_vars['hash_of_inputs']
 
         self.dataset = start_vars['dataset']
         self.this_trait = start_vars['this_trait']

--- a/wqflask/wqflask/marker_regression/run_mapping.py
+++ b/wqflask/wqflask/marker_regression/run_mapping.py
@@ -3,7 +3,6 @@ from base import data_set  # import create_dataset
 
 from pprint import pformat as pf
 
-import hashlib
 import string
 import math
 from decimal import Decimal
@@ -45,16 +44,6 @@ Redis = get_redis_conn()
 class RunMapping:
 
     def __init__(self, start_vars, temp_uuid):
-
-        # Get hash of inputs (as JSON) for sharing results
-        inputs_json = json.dumps(start_vars, sort_keys=True)
-        dhash = hashlib.md5()
-        dhash.update(inputs_json.encode())
-        self.hash_of_inputs = dhash.hexdigest()
-
-        # Just store for one hour on initial load; will be stored for longer if user clicks Share
-        Redis.set(self.hash_of_inputs, inputs_json, ex=60*60)
-
         helper_functions.get_species_dataset_trait(self, start_vars)
 
         # needed to pass temp_uuid to gn1 mapping code (marker_regression_gn1.py)
@@ -64,6 +53,8 @@ class RunMapping:
         if "temp_trait" in start_vars and start_vars['temp_trait'] != "False":
             self.temp_trait = "True"
             self.group = self.dataset.group.name
+
+        self.hash_of_inputs = start_vars['hash_of_inputs']
 
         self.json_data = {}
         self.json_data['lodnames'] = ['lod.hk']

--- a/wqflask/wqflask/marker_regression/run_mapping.py
+++ b/wqflask/wqflask/marker_regression/run_mapping.py
@@ -53,7 +53,7 @@ class RunMapping:
         self.hash_of_inputs = dhash.hexdigest()
 
         # Just store for one hour on initial load; will be stored for longer if user clicks Share
-        Redis.hset("mapping", self.hash_of_inputs, inputs_json, ex=60*60)
+        Redis.set(self.hash_of_inputs, inputs_json, ex=60*60)
 
         helper_functions.get_species_dataset_trait(self, start_vars)
 

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -81,6 +81,8 @@
               <b>Current Date/Time:</b> {{ current_datetime }}<br>
               <br>
               <a class="export_mapping_results" href="#" target="_blank" >Download Full Results</a>
+              <br><br>
+              <button type="button" class="btn btn-default share-results" style="padding-bottom: 2px; padding-top: 2px;"><span class="glyphicon glyphicon-link"></span> Copy Results Link</button>
           </div>
           <div id="gn1_map_options" class="col-xs-6" style="outline: 3px double #AAAAAA; padding: 10px; margin: 10px;">
             <div class="col-xs-8" style="padding: 0px;">

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -18,6 +18,7 @@
         {% if temp_trait is defined %}
         <input type="hidden" name="temp_trait" value="{{ temp_trait }}">
         {% endif %}
+        <input type="hidden" name="inputs_hash" value="{{ hash_of_inputs }}">
         <input type="hidden" name="group" value="{{ dataset.group.name }}">
         <input type="hidden" name="species" value="{{ dataset.group.species }}">
         <input type="hidden" name="trait_id" value="{{ this_trait.name }}">
@@ -82,7 +83,9 @@
               <br>
               <a class="export_mapping_results" href="#" target="_blank" >Download Full Results</a>
               <br><br>
-              <button type="button" class="btn btn-default share-results" style="padding-bottom: 2px; padding-top: 2px;"><span class="glyphicon glyphicon-link"></span> Copy Results Link</button>
+              <button type="button" class="btn btn-default share-results" style="padding-bottom: 2px; padding-top: 2px;"><span class="glyphicon glyphicon-link"></span> Generate Link</button>
+              <br>
+              <input type="text" name="mappingLink" style="display:none;" size="75"></input>
           </div>
           <div id="gn1_map_options" class="col-xs-6" style="outline: 3px double #AAAAAA; padding: 10px; margin: 10px;">
             <div class="col-xs-8" style="padding: 0px;">
@@ -668,6 +671,21 @@
         $('#gn1_map_tab').click(function() {
           $('#gn1_map_options').css("display", "block")
         })
+
+        $('.share-results').click(function() {
+            hash = $('input[name=inputs_hash]').val()
+            $.ajax({
+                method: "POST",
+                url: "/cache_mapping_inputs",
+                data: {
+                    inputs_hash: hash
+                },
+                success: function() {
+                  $('input[name=mappingLink]').val(window.location.origin + "/run_mapping?hash=" + hash).show();
+                }
+            });
+        })
+
     </script>
 
 {% endblock %}

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -81,11 +81,14 @@
               {% endif %}
               <b>Current Date/Time:</b> {{ current_datetime }}<br>
               <br>
-              <a class="export_mapping_results" href="#" target="_blank" >Download Full Results</a>
+              <button class="btn btn-default export_mapping_results">Download Full Results</button>
               <br><br>
-              <button type="button" class="btn btn-default share-results" style="padding-bottom: 2px; padding-top: 2px;"><span class="glyphicon glyphicon-link"></span> Generate Link</button>
-              <br>
-              <input type="text" name="mappingLink" style="display:none;" size="75"></input>
+              <div class="input-group">
+                <input type="text" class="form-control" name="mappingLink" size="75"></input>
+                <div class="input-group-btn">
+                  <button class="btn btn-default share-results" type="button">Copy and Share</button>
+                </div>
+              </div>
           </div>
           <div id="gn1_map_options" class="col-xs-6" style="outline: 3px double #AAAAAA; padding: 10px; margin: 10px;">
             <div class="col-xs-8" style="padding: 0px;">
@@ -672,8 +675,11 @@
           $('#gn1_map_options').css("display", "block")
         })
 
+        hash = $('input[name=inputs_hash]').val();
+        mappingLink = window.location.origin + "/run_mapping?hash=" + hash;
+        $('input[name=mappingLink]').width(mappingLink.length*0.95 + "ch")
+        $('input[name=mappingLink]').val(mappingLink);
         $('.share-results').click(function() {
-            hash = $('input[name=inputs_hash]').val()
             $.ajax({
                 method: "POST",
                 url: "/cache_mapping_inputs",
@@ -681,7 +687,8 @@
                     inputs_hash: hash
                 },
                 success: function() {
-                  $('input[name=mappingLink]').val(window.location.origin + "/run_mapping?hash=" + hash).show();
+                  document.querySelector("input[name='mappingLink']").select();
+                  document.execCommand('copy');
                 }
             });
         })

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -677,9 +677,13 @@ def loading_page():
     return rendered_template
 
 
-@app.route("/run_mapping", methods=('POST',))
+@app.route("/run_mapping", methods=('POST','GET'))
 def mapping_results_page():
-    initial_start_vars = request.form
+    if request.method == "GET":
+        initial_start_vars = json.loads(Redis.get(request.args.get("hash")))
+    else:
+        initial_start_vars = request.form
+
     temp_uuid = initial_start_vars['temp_uuid']
     wanted = (
         'trait_id',

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -741,7 +741,8 @@ def mapping_results_page():
         'mapmodel_rqtl',
         'temp_trait',
         'n_samples',
-        'transform'
+        'transform',
+        'hash_of_inputs'
     )
     start_vars = {}
     for key, value in list(initial_start_vars.items()):
@@ -780,6 +781,14 @@ def mapping_results_page():
 
     return rendered_template
 
+@app.route("/cache_mapping_inputs", methods=('POST',))
+def cache_mapping_inputs():
+    TWO_MONTHS = 60 * 60 * 24 * 60
+    cache_id = request.form.get("inputs_hash")
+    inputs_json = Redis.get(cache_id)
+    Redis.set(cache_id, inputs_json, ex=TWO_MONTHS)
+
+    return "Success"
 
 @app.route("/export_mapping_results", methods=('POST',))
 def export_mapping_results():


### PR DESCRIPTION
This PR will add the option to get a shareable link for mapping results.

The way I'm planning on doing this will rely on the caching of the actual mapping tools themselves. While I would like to avoid re-running all the code for actually drawing the figure (etc), it isn't really practical due to how much of a mess the mapping display code is. The simplest way to do this seems to be to store the options as they exist at the beginning of run_mapping.py, because at that point the options can be JSON serialized. In display_mapping_results.py the options are no longer JSON serializable, so I'm not sure how to store them at that point without having to add a bunch of extra code that allows the dataset to be passed as either a string or object, etc.