### PR TITLE
Feature/edited sample data in scatterplots

### DIFF
--- a/wqflask/wqflask/correlation/corr_scatter_plot.py
+++ b/wqflask/wqflask/correlation/corr_scatter_plot.py
@@ -1,9 +1,13 @@
+import json
 import math
+
+from redis import Redis
+Redis = Redis()
 
 from flask import g
 
 from base.trait import create_trait, retrieve_sample_data
-from base import data_set
+from base import data_set, webqtlCaseData
 from utility import corr_result_helpers
 from scipy import stats
 import numpy as np
@@ -39,13 +43,14 @@ class CorrScatterPlot:
         if self.dataset_1.group.f1list != None:
             primary_samples += self.dataset_1.group.f1list
 
-        self.trait_1 = retrieve_sample_data(
-            self.trait_1, self.dataset_1, primary_samples)
-        self.trait_2 = retrieve_sample_data(
-            self.trait_2, self.dataset_2, primary_samples)
-
-        samples_1, samples_2, num_overlap = corr_result_helpers.normalize_values_with_samples(
-            self.trait_1.data, self.trait_2.data)
+        if 'dataid' in params:
+            trait_data_dict = json.loads(Redis.get(params['dataid']))
+            trait_data = {key:webqtlCaseData.webqtlCaseData(key, float(trait_data_dict[key])) for (key, value) in trait_data_dict.items() if trait_data_dict[key] != "x"}
+            samples_1, samples_2, num_overlap = corr_result_helpers.normalize_values_with_samples(
+                self.trait_1.data, trait_data)
+        else:
+            samples_1, samples_2, num_overlap = corr_result_helpers.normalize_values_with_samples(
+                self.trait_1.data, self.trait_2.data)
 
         self.data = []
         self.indIDs = list(samples_1.keys())

--- a/wqflask/wqflask/marker_regression/display_mapping_results.py
+++ b/wqflask/wqflask/marker_regression/display_mapping_results.py
@@ -244,6 +244,7 @@ class DisplayMappingResults:
     def __init__(self, start_vars):
         self.temp_uuid = start_vars['temp_uuid']
         self.hash_of_inputs = start_vars['hash_of_inputs']
+        self.dataid = start_vars['dataid']
 
         self.dataset = start_vars['dataset']
         self.this_trait = start_vars['this_trait']

--- a/wqflask/wqflask/marker_regression/run_mapping.py
+++ b/wqflask/wqflask/marker_regression/run_mapping.py
@@ -55,6 +55,7 @@ class RunMapping:
             self.group = self.dataset.group.name
 
         self.hash_of_inputs = start_vars['hash_of_inputs']
+        self.dataid = start_vars['dataid']
 
         self.json_data = {}
         self.json_data['lodnames'] = ['lod.hk']

--- a/wqflask/wqflask/templates/correlation_page.html
+++ b/wqflask/wqflask/templates/correlation_page.html
@@ -299,7 +299,7 @@
               'orderSequence': [ "desc", "asc"],
               'render': function(data) {
                 if (data.sample_r != "N/A") {
-                  return "<a target\"_blank\" href=\"corr_scatter_plot?method=" + corr_method + "&dataset_1={% if this_dataset.name == 'Temp' %}Temp_{{ this_dataset.group }}{% else %}{{ this_dataset.name }}{% endif %}&dataset_2=" + data.dataset + "&trait_1={{ this_trait.name }}&trait_2=" + data.trait_id + "\">" + data.sample_r + "</a>"
+                  return "<a target\"_blank\" href=\"corr_scatter_plot?method=" + corr_method + "&dataid={{ dataid }}&dataset_1={% if this_dataset.name == 'Temp' %}Temp_{{ this_dataset.group }}{% else %}{{ this_dataset.name }}{% endif %}&dataset_2=" + data.dataset + "&trait_1={{ this_trait.name }}&trait_2=" + data.trait_id + "\">" + data.sample_r + "</a>"
                 } else {
                   return data.sample_r
                 }

--- a/wqflask/wqflask/templates/mapping_results.html
+++ b/wqflask/wqflask/templates/mapping_results.html
@@ -420,7 +420,7 @@
                 'data': null,
                 'render': function(data, type, row, meta) {
                   {% if geno_db_exists == "True" %}
-                  return '<a target"_blank" href="corr_scatter_plot?method=pearson&dataset_1={{ dataset.group.name }}Geno&dataset_2={{ dataset.name }}&trait_1=' + data.name + '&trait_2={{ this_trait.name }}">' + String(parseFloat(data.additive).toFixed(3)) + '</a>'
+                  return '<a target"_blank" href="corr_scatter_plot?method=pearson&dataset_1={{ dataset.group.name }}Geno&dataset_2={{ dataset.name }}&trait_1=' + data.name + '&trait_2={{ this_trait.name }}&dataid={{ dataid }}">' + String(parseFloat(data.additive).toFixed(3)) + '</a>'
                   {% else %}
                   return String(parseFloat(data.additive).toFixed(3))
                   {% endif %}

--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -754,7 +754,8 @@ def mapping_results_page():
         'temp_trait',
         'n_samples',
         'transform',
-        'hash_of_inputs'
+        'hash_of_inputs',
+        'dataid'
     )
     start_vars = {}
     for key, value in list(initial_start_vars.items()):
@@ -762,6 +763,13 @@ def mapping_results_page():
             start_vars[key] = value
 
     start_vars['hash_of_inputs'] = hash_of_inputs
+
+    # Store trait sample data in Redis, so additive effect scatterplots can include edited values
+    dhash = hashlib.md5()
+    dhash.update(start_vars['sample_vals'].encode())
+    samples_hash = dhash.hexdigest()
+    Redis.set(samples_hash, start_vars['sample_vals'], ex=7*24*60*60)
+    start_vars['dataid'] = samples_hash
 
     version = "v3"
     key = "mapping_results:{}:".format(


### PR DESCRIPTION
This PR allows edited sample data to be used in scatterplots linked from the correlation and mapping results pages.

It works by storing the edited sample data as JSON in Redis and passing the key to the scatterplot page. The page can still be used without the dataid, but it'll use the default values for the traits in question.
