### PR TITLE
Changes to sample data editing

### DIFF
--- a/wqflask/wqflask/templates/edit_phenotype.html
+++ b/wqflask/wqflask/templates/edit_phenotype.html
@@ -23,6 +23,7 @@
             <input name="inbred-set-id" class="changed" type="hidden" value="{{ publish_xref.inbred_set_id }}"/>
             <input name="phenotype-id" class="changed" type="hidden" value="{{ publish_xref.phenotype_id }}"/>
             <input name="comments" class="changed" type="hidden" value="{{ publish_xref.comments }}"/>
+            <input name="edited" class="changed" type="hidden" value="false"/>
         </div>
 	</div>
     <div>
@@ -208,10 +209,10 @@
                     <td><input type="checkbox"></td>
                     <td>{{ loop.index }}</td>
                     <td>{{ sample }}</td>
-                    <td><input type="text" name="value:{{ sample }}" value="{% if sample_data.get(sample) %}{{ '%0.3f' | format(sample_data.get(sample).value | float) }}{% else %}x{% endif %}" size=4 maxlength=4></input></td>
+                    <td><input type="text" name="value:{{ sample }}" class="table_input" value="{% if sample_data.get(sample) %}{{ '%0.3f' | format(sample_data.get(sample).value | float) }}{% else %}x{% endif %}" size=4 maxlength=4></input></td>
                     <td>±</td>
-                    <td><input type="text" name="error:{{ sample }}" step='0.001' value="{% if sample_data.get(sample).error %}{{ '%0.3f' | format(sample_data.get(sample).error | float) }}{% else %}x{% endif %}" size=4 maxlength=4></input></td>
-                    <td><input type="text" name="n_cases:{{ sample }}" value="{% if sample_data.get(sample).n_cases %}{{ sample_data.get(sample).n_cases }}{% else %}x{% endif %}" size=3 maxlength=3></input></td>
+                    <td><input type="text" name="error:{{ sample }}" class="table_input" value="{% if sample_data.get(sample).error %}{{ '%0.3f' | format(sample_data.get(sample).error | float) }}{% else %}x{% endif %}" size=4 maxlength=4></input></td>
+                    <td><input type="text" name="n_cases:{{ sample }}" class="table_input" value="{% if sample_data.get(sample).n_cases %}{{ sample_data.get(sample).n_cases }}{% else %}x{% endif %}" size=3 maxlength=3></input></td>
                 </tr>
                 {% endfor %}
             </tbody>
@@ -233,6 +234,11 @@
 
  $("input[type=submit]").click(function(){
      $(":input:not(.changed)").attr("disabled", "disabled");
+ });
+
+ // This is an awkward way to detect changes to table data, so it doesn't process it otherwise
+ $(".table_input").change(function(){
+    $("input[name=edited]").val("true");
  });
 </script>
 {% endblock %}


### PR DESCRIPTION
This PR will make a couple changes to sample data editing:

- Values will be editable for samples that don't currently have values. Currently you can only edit sample values for samples that already have values; this is because it just pulls the sample data from the DB and wasn't accounting for the sample list
- It will be possible to submit sample data changes via an HTML table, instead of just as a CSV import

The corresponding GN3 PR is here - https://github.com/genenetwork/genenetwork3/pull/117