### PR TITLE
Create new entry-point module to reduce chances of circular imports.

### DIFF
--- a/wqflask/gn2_main.py
+++ b/wqflask/gn2_main.py
@@ -1,0 +1,19 @@
+"""Main application entry point."""
+
+from wqflask import app
+
+
+from wqflask import docs
+from wqflask import gsearch
+from wqflask import db_info
+from wqflask import user_login
+from wqflask.api import router
+from wqflask import user_session
+from wqflask import group_manager
+from wqflask import export_traits
+from wqflask import search_results
+from wqflask import resource_manager
+from wqflask import update_search_results
+
+import wqflask.views
+import wqflask.partial_correlations_views

--- a/wqflask/run_gunicorn.py
+++ b/wqflask/run_gunicorn.py
@@ -9,7 +9,7 @@
 
 print("===> Starting up Gunicorn process")
 
-from wqflask import app
+from gn2_main import app
 from utility.startup_config import app_config
 
 app_config()

--- a/wqflask/runserver.py
+++ b/wqflask/runserver.py
@@ -7,7 +7,7 @@
 #
 # /sbin/iptables -A INPUT -p tcp -i eth0 -s ! 71.236.239.43 --dport 5003 -j DROP
 
-from wqflask import app
+from gn2_main import app
 from utility.startup_config import app_config
 from utility.tools import WEBSERVER_MODE, SERVER_PORT
 

--- a/wqflask/wqflask/__init__.py
+++ b/wqflask/wqflask/__init__.py
@@ -114,19 +114,3 @@ def include_admin_role_class():
 @app.context_processor
 def include_data_role_class():
     return {'DataRole': DataRole}
-
-
-from wqflask.api import router
-from wqflask import group_manager
-from wqflask import resource_manager
-from wqflask import search_results
-from wqflask import export_traits
-from wqflask import gsearch
-from wqflask import update_search_results
-from wqflask import docs
-from wqflask import db_info
-from wqflask import user_login
-from wqflask import user_session
-
-import wqflask.views
-import wqflask.partial_correlations_views


### PR DESCRIPTION
This commit creates a new entry-point module (wqflask/gn2_main.py) and imports all the other modules that import the application object with something like:

    `from wqflask import app`

This breaks the subtle circular-import cycle that tends to cause a lot of inconveniences when developing the application.