### PR TITLE
Refactor configurations 20230705

### DIFF
--- a/bin/genenetwork2
+++ b/bin/genenetwork2
@@ -64,16 +64,11 @@ GUIX_SITE=$GN2_BASE_DIR/lib/python3.8/site-packages
 if [ -d "${GUIX_SITE}" ]; then
     echo INFO: GN2 is running from GNU Guix
     GN2_BASE_DIR=$GUIX_SITE
-    GN_VERSION="${GN2_ID}:$(cat "${GN2_BASE_DIR}"/etc/VERSION)"
-    export GN_VERSION
 else
     echo INFO: GN2 is running from a source tree
     GIT_HASH=$(git rev-parse HEAD)
     GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-    GN_VERSION="${GN2_ID}:$(cat "${GN2_BASE_DIR}"/etc/VERSION)-${GIT_BRANCH}-$(echo "${GIT_HASH}" | cut -c1-9)"
-    export GN_VERSION
 fi
-echo GN_VERSION="${GN_VERSION}"
 
 if [ "$1" = "-c" -o "$1" = "-gunicorn" ]; then
     echo "Can not use $1 switch without default settings file"

--- a/wqflask/utility/tools.py
+++ b/wqflask/utility/tools.py
@@ -4,6 +4,8 @@
 import os
 import sys
 import json
+import socket
+from pathlib import Path
 
 from wqflask import app
 
@@ -255,9 +257,27 @@ def show_settings():
             print(("%s: %s%s%s%s" % (k, GREEN, BOLD, app.config[k], ENDC)),
                   file=sys.stderr)
 
+def gn_version_repo_info(root_dir):
+    """retrieve the branch name and abbreviated commit hash."""
+    try:
+        from git import Repo
+        repo = Repo(root_dir)
+        return f"{repo.head.ref.name}-{repo.head.commit.hexsha[0:9]}"
+    except:
+        return ""
+
+def gn_version():
+    """Compute and return the version of the application."""
+    hostname = socket.gethostname()
+    basedir = Path(__file__).absolute().parent.parent.parent
+    with open(Path(basedir, "etc", "VERSION"), encoding="utf8") as version_file:
+        version_contents = version_file.read().strip()
+    base_version = f"{hostname}:{basedir.name}:{version_contents}"
+    repo_info = gn_version_repo_info(basedir)
+    return f"{base_version}-{repo_info}" if bool(repo_info) else base_version
 
 # Cached values
-GN_VERSION = get_setting('GN_VERSION')
+GN_VERSION = gn_version()
 HOME = get_setting('HOME')
 SERVER_PORT = get_setting('SERVER_PORT')
 WEBSERVER_MODE = get_setting('WEBSERVER_MODE')

--- a/wqflask/utility/tools.py
+++ b/wqflask/utility/tools.py
@@ -56,16 +56,14 @@ def get_setting(command_id, guess=None):
     # print("Looking for "+command_id+"\n")
     command = value(os.environ.get(command_id))
     if command is None or command == "":
-        command = OVERRIDES.get(command_id)  # currently not in use
+        # ---- Check whether setting exists in app
+        command = value(app.config.get(command_id))
         if command is None:
-            # ---- Check whether setting exists in app
-            command = value(app.config.get(command_id))
-            if command is None:
-                command = value(guess)
-                if command is None or command == "":
-                    # print command
-                    raise Exception(
-                        command_id + ' setting unknown or faulty (update default_settings.py?).')
+            command = value(guess)
+            if command is None or command == "":
+                # print command
+                raise Exception(
+                    command_id + ' setting unknown or faulty (update default_settings.py?).')
     # print("Set "+command_id+"="+str(command))
     return command
 
@@ -244,7 +242,6 @@ def show_settings():
     log_level = getattr(logging, LOG_LEVEL.upper())
     logging.basicConfig(level=log_level)
 
-    logger.info(OVERRIDES)
     logger.info(BLUE + "Mr. Mojo Risin 2" + ENDC)
     keylist = list(app.config.keys())
     print("runserver.py: ****** Webserver configuration - k,v pairs from app.config ******",

--- a/wqflask/wqflask/metadata_edits.py
+++ b/wqflask/wqflask/metadata_edits.py
@@ -148,7 +148,7 @@ def display_phenotype_metadata(dataset_id: str, name: str):
             dataset_id=dataset_id,
             name=name,
             resource_id=request.args.get("resource-id"),
-            version=os.environ.get("GN_VERSION"),
+            version=get_setting("GN_VERSION"),
             dataset_name=request.args["dataset_name"])
 
 
@@ -165,7 +165,7 @@ def display_probeset_metadata(name: str):
             probeset=_d.get("probeset"),
             name=name,
             resource_id=request.args.get("resource-id"),
-            version=os.environ.get("GN_VERSION"),
+            version=get_setting("GN_VERSION"),
             dataset_name=request.args["dataset_name"]
         )
 
@@ -620,7 +620,7 @@ def show_history(dataset_id: str = "", name: str = ""):
     return render_template(
         "edit_history.html",
         diff=diff_data_,
-        version=os.environ.get("GN_VERSION"),
+        version=get_setting("GN_VERSION"),
     )
 
 


### PR DESCRIPTION
This PR:

- Removes an unused, global variable `OVERRIDES`
- Updates code to get the application configuration variables from the main application configuration file(s) and not the **envvars** directly
- Computes the `GN_VERSION` value in the code at setup and not in the startup shell script