### PR TITLE
Remove GN2 generif link.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,2 @@
 #### Description
 <!--Brief description of the PR. What does this PR do? -->
-
-#### How should this be tested?
-<!-- What should you do to test this PR? Is there any manual quality
-assurance checks that should be done. What are the expectations -->
-
-#### Any background context you want to provide?
-<!-- Anything the reviewer should be aware of ahead of testing -->
-
-#### What are the relevant pivotal tracker stories?
-<!-- Does this PR track anything anywhere? -->
-
-#### Screenshots (if appropriate)
-
-#### Questions
-<!-- Are there any questions for the reviewer -->

--- a/wqflask/wqflask/templates/show_trait_details.html
+++ b/wqflask/wqflask/templates/show_trait_details.html
@@ -229,7 +229,6 @@
         {% endif %}
         {% if this_trait.symbol != None %}
 	<button type="button" class="btn btn-default" title="Write or review comments about this gene" onclick="window.open('http://gn1.genenetwork.org/webqtl/main.py?FormID=geneWiki&symbol={{ this_trait.symbol }}', '_blank')">(GN1) GeneWiki</button>
-        <button type="button" class="btn btn-default" title="Write or review comments about this gene" onclick="window.open('{{ url_for('display_generif_page', symbol=this_trait.symbol) }}', '_blank')">(GN2) GeneWiki</button>
         {% if dataset.group.species == "mouse" or dataset.group.species == "rat" %}
         <button type="button" class="btn btn-default" title="View SNPs and Indels" onclick="window.open('/snp_browser?first_run=true&species={{ dataset.group.species }}&gene_name={{ this_trait.symbol }}&limit_strains=on', '_blank')">SNPs</button>
         {% endif %}


### PR DESCRIPTION
This pull request eliminates the GN2 generif link, which is currently inactive. GeneRIF pages are undergoing restructuring to incorporate HTMX⁰. Additionally, this PR streamlines our PR template by removing redundant sections, as they are not utilized.

⁰ We aim to embrace HTMX to alleviate JavaScript fatigue and enhance server-side processing for faster page loading.
