### PR TITLE
Disable SSL check when checking whether user is logged in.

### DIFF
--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -164,7 +164,7 @@ def index_page():
                                anon_id=anon_id)
 
     return no_token_get(
-        f"auth/user/collections/{anon_id}/list").either(
+        f"auth/user/collections/{anon_id}/list", verify=False).either(
             lambda err: __render__([]),
             __render__)
 


### PR DESCRIPTION
Right now MR has the following trace:


```
2023-11-06 11:54:10 During handling of the above exception, another exception occurred:       
2023-11-06 11:54:10                                                                           
2023-11-06 11:54:10 Traceback (most recent call last):                                        
2023-11-06 11:54:10   File "/gnu/store/626l1wxy90ak1j6k315b3mmh2wx8wi87-profile/lib/python3.10
/site-packages/flask/app.py", line 1523, in full_dispatch_request                             
2023-11-06 11:54:10     rv = self.dispatch_request()                                          
2023-11-06 11:54:10   File "/gnu/store/626l1wxy90ak1j6k315b3mmh2wx8wi87-profile/lib/python3.10
/site-packages/flask/app.py", line 1509, in dispatch_request
2023-11-06 11:54:10     return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view
_args)                                                                                        
2023-11-06 11:54:10   File "/genenetwork2/wqflask/wqflask/views.py", line 166, in index_page  
2023-11-06 11:54:10     return no_token_get(
2023-11-06 11:54:10   File "/genenetwork2/wqflask/wqflask/oauth2/client.py", line 79, in no_to
ken_get
2023-11-06 11:54:10     resp = requests.get(urljoin(AUTH_SERVER_URL, uri_path), **kwargs)
2023-11-06 11:54:10   File "/gnu/store/626l1wxy90ak1j6k315b3mmh2wx8wi87-profile/lib/python3.10
/site-packages/requests/api.py", line 73, in get
2023-11-06 11:54:10     return request("get", url, params=params, **kwargs)
2023-11-06 11:54:10   File "/gnu/store/626l1wxy90ak1j6k315b3mmh2wx8wi87-profile/lib/python3.10
/site-packages/requests/api.py", line 59, in request
2023-11-06 11:54:10     return session.request(method=method, url=url, **kwargs)
2023-11-06 11:54:10   File "/gnu/store/626l1wxy90ak1j6k315b3mmh2wx8wi87-profile/lib/python3.10
/site-packages/requests/sessions.py", line 587, in request
2023-11-06 11:54:10     resp = self.send(prep, **send_kwargs)
2023-11-06 11:54:10   File "/gnu/store/626l1wxy90ak1j6k315b3mmh2wx8wi87-profile/lib/python3.10
/site-packages/requests/sessions.py", line 701, in send
2023-11-06 11:54:10     r = adapter.send(request, **kwargs)
2023-11-06 11:54:10   File "/gnu/store/626l1wxy90ak1j6k315b3mmh2wx8wi87-profile/lib/python3.10
/site-packages/requests/adapters.py", line 563, in send
2023-11-06 11:54:10     raise SSLError(e, request=request)
2023-11-06 11:54:10 requests.exceptions.SSLError: HTTPSConnectionPool(host='localhost', port=9
094): Max retries exceeded with url: /auth/user/collections/f571b9a7-75f2-4f49-8ce0-e69b79806a
f2/list (Caused by SSLError(SSLZeroReturnError(6, 'TLS/SSL connection has been closed (EOF) (_
[...]
```

This PR disables SSL verification for auth hoping that it will fix the above error.
