### PR TITLE
Update phenotype retrieval route, incorporate group parameter.

### DIFF
--- a/wqflask/wqflask/views.py
+++ b/wqflask/wqflask/views.py
@@ -1133,7 +1133,10 @@ def get_publication(name):
 
 
 @app.route("/phenotypes/<name>", methods=('GET',))
-def get_phenotype(name):
+@app.route("/phenotypes/<group>/<name>", methods=('GET',))
+def get_phenotype(name, group=None):
+    if group:
+        name = f"{group}_{name}"
     metadata = requests.get(
         urljoin(
             GN3_LOCAL_URL,


### PR DESCRIPTION

This PR enhances fetching phenotypes by adding a `group` parameter, allowing for improved categorization.  Now when accessing a phenotype, e.g. BXD_10007, you can use the `group/trait` to fetch the data, which looks like: `BXD/10007`.
