### PR TITLE
Phenotype page minor updates

### DIFF
--- a/wqflask/wqflask/templates/phenotype.html
+++ b/wqflask/wqflask/templates/phenotype.html
@@ -47,11 +47,17 @@
                 {% endif %}
             </td>
         </tr>
-
-        <tr>
-            <td><b>Title</b></td>
-	    <td><a href="{{ metadata.references.id }}" target="_blank">{{ metadata.title or "N/A"}}</a></td>
-        </tr>
+	{% if metadata.references.id %}
+	<tr>
+	    <td><b>Publication</b></td>
+	    <td>
+		<i>{{ metadata.references.title }}.</i> {{ ', '.join(metadata.references.creator) }}. {{ metadata.references.year }} {{ metadata.references.month }}{{ metadata.references.volume }}:{{ metadata.references.page }}
+		<sup>
+		    <a href="{{ metadata.references.id }}" target="_blank"><small>PubMed<sup>&#32;<span class="glyphicon glyphicon-new-window"></span></sup></small></a>
+		</sup>
+	    </td>
+	</tr>
+	{% endif %}
 
 	<tr>
 	    <td><b>Database</b></td>
@@ -63,44 +69,27 @@
 	</tr>
 
 	<tr>
-	    <td><b>Journal</b></td>
-	    <td>{{ metadata.journal or "N/A"}}</td>
-	</tr>
-
-	<tr>
-	    <td><b>Volume</b></td>
-	    <td>{{ metadata.volume or "N/A"}}</td>
-	</tr>
-
-	<tr>
-	    <td><b>Month</b></td>
-	    <td>{{ metadata.month or "N/A"}}</td>
-	</tr>
-
-	<tr>
-	    <td><b>Page</b></td>
-	    <td>{{ metadata.page or "N/A"}}</td>
-	</tr>
-
-	<tr>
-	    <td><b>Year</b></td>
-	    <td>{{ metadata.year or "N/A"}}</td>
-	</tr>
-
-	<tr>
 	    <td><b>Mean</b></td>
 	    <td>{{ metadata.mean or "N/A"}}</td>
 	</tr>
 
 	<tr>
-	    <td><b>LRS</b></td>
-	    <td>{{ metadata.LRS or "N/A"}}</td>
+	    <td><b>Peak -logP</b></td>
+	    <td>{{ metadata.lodScore or "N/A"}}</td>
 	</tr>
 
 	<tr>
-	    <td><b>Additive</b></td>
+	    <td><b>Effect Size</b></td>
 	    <td>{{ metadata.additive or "N/A"}}</td>
 	</tr>
+	{% if metadata.references.id %}
+	<tr>
+	    <td><b>Resource Links</b></td>
+	    <td>
+		<a href="{{ metadata.references.id }}" target="_blank">PubMed</a>
+	    </td>
+	</tr>
+	{% endif %}
     </table>
 </div>
 

--- a/wqflask/wqflask/templates/phenotype.html
+++ b/wqflask/wqflask/templates/phenotype.html
@@ -82,6 +82,12 @@
 	    <td><b>Effect Size</b></td>
 	    <td>{{ metadata.additive or "N/A"}}</td>
 	</tr>
+	{% if metadata.locus %}
+	<tr>
+	    <td><b>Peak Location</b></td>
+	    <td>Chr{{ metadata.locus.chromosome }}: {{ metadata.locus.mb }}</td>
+	</tr>
+	{% endif %}
 	{% if metadata.references.id %}
 	<tr>
 	    <td><b>Resource Links</b></td>

--- a/wqflask/wqflask/templates/phenotype.html
+++ b/wqflask/wqflask/templates/phenotype.html
@@ -99,7 +99,7 @@
 
 	<tr>
 	    <td><b>Additive</b></td>
-	    <td>{{ metadata.Additive or "N/A"}}</td>
+	    <td>{{ metadata.additive or "N/A"}}</td>
 	</tr>
     </table>
 </div>

--- a/wqflask/wqflask/templates/phenotype.html
+++ b/wqflask/wqflask/templates/phenotype.html
@@ -3,7 +3,6 @@
 {% block css %}
 <style type="text/css">
  .page-header {
-     text-underline-offset: 0.5rem;
      padding: 1em;
  }
 </style>
@@ -14,7 +13,7 @@
 {% block content %}
 
 <h1 class="page-header">
-    <u>Phenotype: {{ metadata.traitName }} ({{ metadata.abbreviation}})</u>
+    Phenotype: {{ metadata.traitName }} ({{ metadata.abbreviation }})
 </h1>
 
 <div class="container">


### PR DESCRIPTION
#### Description
This PR changes the phenotype display page, including the addition of a "Peak Location".  It refines the presentation of publication details, such as titles, creators, publication date, volume, and page in the phenotype template.  Moreover, corrections have been made to ensure accurate fetching of the additive value on the phenotype display.  The underline at the page-header is also removed.  The phenotype retrieval route in the view was also updated to incorporate a group parameter for more refined phenotype retrieval.