### PR TITLE
Update ProbeSet Page with more metadata

### DIFF
--- a/gn2/wqflask/templates/probeset.html
+++ b/gn2/wqflask/templates/probeset.html
@@ -26,23 +26,22 @@ mRNA Expression:
     <h3>{{ metadata.description }}</h3>
     {% endif %}
     <table class="table">
-	{% if metadata.dataset %}
+	{% if metadata.group and metadata.species %}
 	<tr>
             <td><b>Group </b></td>
             <td>
-		<a href="{{ metadata.group }}" target="_blank">{{ metadata.dataset }}</a>
+		{{ metadata.species|capitalize }}: {{ metadata.group }}
 	    </td>
 	</tr>
+	{% endif %}
+
+	{% if metadata.tissue %}
 	<tr>
-            <td><b>Dataset </b></td>
-            <td>
-		<a href="{{ metadata.group }}" target="_blank">{{ metadata.datasetName }}</a>
+	    <td><b>Tissue</b></td>
+	    <td>
+		{{ metadata.tissue }}
 	    </td>
-        </tr>
-	<tr>
-            <td><b>Tissue</b></td>
-            <td>{{ metadata.tissue}}</td>
-		</tr>
+	</tr>
 	{% endif %}
 
 	{% if metadata.symbol %}
@@ -81,6 +80,13 @@ mRNA Expression:
 	    </td>
         </tr>
         {% endif %}
+
+	{% if metadata.dataset and dataset %}
+	<tr>
+	    <td><b>Database</b></td>
+	    <td><a href={{ url_for('get_dataset', name=dataset) }} target="_blank">{{ metadata.dataset }}</a></td>
+	</tr>
+	{% endif %}
 
 	{% if metadata.specificity or metadata.blatScore %}
         <tr>

--- a/gn2/wqflask/templates/probeset.html
+++ b/gn2/wqflask/templates/probeset.html
@@ -22,6 +22,10 @@ mRNA Expression:
 	mRNA Expression:
 	{{ metadata.name or name }}
     </h2>
+    {% if name and dataset %}
+    <a href={{ url_for('show_trait_page', dataset=dataset, trait_id=name) }} target="blank">[compare]</a>
+    {% endif %}
+
     {% if metadata.description %}
     <h3>{{ metadata.description }}</h3>
     {% endif %}

--- a/gn2/wqflask/templates/probeset.html
+++ b/gn2/wqflask/templates/probeset.html
@@ -72,6 +72,13 @@ mRNA Expression:
 	</tr>
 	{% endif %}
 
+	{% if summary %}
+	<tr>
+	    <td><b>Summary</b></td>
+	    <td>{{ summary }}</td>
+	</tr>
+	{% endif %}
+
         {% if metadata.blatSeq %}
         <tr>
 	    <td><b>BLAT Sequence</b></td>

--- a/gn2/wqflask/views.py
+++ b/gn2/wqflask/views.py
@@ -1189,11 +1189,21 @@ def get_probeset(name, dataset=None):
             GN3_LOCAL_URL,
             f"/api/metadata/probesets/{name}")
     ).json()
+    summary = None
+    if gene_id := metadata.get("geneID"):
+        gene_id = gene_id.get("id").split("=")[-1]
+        result = json.loads(
+            requests.get(
+                f"http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=gene&id={gene_id}&retmode=json"
+            ).content
+        )['result']
+        summary = result[gene_id]['summary']
     return render_template(
         "probeset.html",
         name=name,
         dataset=dataset,
         metadata=metadata,
+        summary=summary,
     )
 
 

--- a/gn2/wqflask/views.py
+++ b/gn2/wqflask/views.py
@@ -1182,7 +1182,8 @@ def get_phenotype(name, group=None):
 
 
 @app.route("/probesets/<name>", methods=('GET',))
-def get_probeset(name):
+@app.route("/probesets/<dataset>/<name>", methods=["GET"])
+def get_probeset(name, dataset=None):
     metadata = requests.get(
         urljoin(
             GN3_LOCAL_URL,
@@ -1191,6 +1192,7 @@ def get_probeset(name):
     return render_template(
         "probeset.html",
         name=name,
+        dataset=dataset,
         metadata=metadata,
     )
 


### PR DESCRIPTION
#### Description
This pull request introduces several improvements to the probeset page:
- Added a compare button to display the current probeset page.
- Included Entrez summary for a geneID on the probeset page.
- Enhanced the functionality to include dataset metadata when a dataset is specified.

Related: https://github.com/genenetwork/genenetwork3/pull/143