### PR TITLE
Remove redundant search endpoints

### DIFF
--- a/gn2/wqflask/templates/dataset.html
+++ b/gn2/wqflask/templates/dataset.html
@@ -40,31 +40,6 @@
  .panel-metadata dt::after {
      content: ":";
  }
-
- .search {
-     width: 50%;
-     margin: 1em auto;
- }
- .has-search .form-control-feedback {
-     right: initial;
-     left: 0;
-     color: #ccc;
- }
-
- .has-search .form-control {
-     padding-right: 12px;
-     padding-left: 34px;
- }
-
- .search {
-     transform: scale(1.5, 1.5);
- }
- .search input {
-     min-width: 17em;
- }
- .dataset-search {
-     padding: 0 17%;
- }
 </style>
 {% endblock %}
 
@@ -348,7 +323,7 @@
 </div>
 
 {% else %}
-<div class="container dataset-search">
+<div class="container">
     <p class="lead">We appreciate your interest, but unfortunately, we don't have any additional information available for: <strong>{{ name }}</strong>.  If you have other inquiries or need assistance with something else, please don't hesitate to get in touch with us.
 </div>
 

--- a/gn2/wqflask/views.py
+++ b/gn2/wqflask/views.py
@@ -1234,8 +1234,8 @@ def get_dataset(name):
         lambda err: {"roles": []},
         lambda val: val
     )
-
-    metadata["editable"] = "group:resource:edit-resource" in result["roles"]
+    if metadata:
+        metadata["editable"] = "group:resource:edit-resource" in result["roles"]
     return render_template(
         "dataset.html",
         name=name,


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->
This PR removes some old styling for dataset search.  ATM this is redundant.  The idea is that once we've ironed out local/global search, we could re-introduce it again.