### PR TITLE
fix: reorder jquery-ui before bootstrap

### DIFF
--- a/gn2/wqflask/templates/base.html
+++ b/gn2/wqflask/templates/base.html
@@ -286,6 +286,7 @@
                 </div>
 		</div>
                 <script src="{{ url_for('js', filename='jquery/jquery.min.js') }}" type="text/javascript"></script>
+                <script src="{{ url_for('js', filename='jquery-ui/jquery-ui.min.js') }}" type="text/javascript"></script>
                 <script src="{{ url_for('js', filename='bootstrap/js/bootstrap.min.js') }}" type="text/javascript"></script>
                 <script src="/static/new/javascript/search_autocomplete.js"></script>
                 <script>
@@ -339,7 +340,7 @@
                  });
                 </script>
                 <script src="{{ url_for('js', filename='jquery-cookie/jquery.cookie.js') }}" type="text/javascript"></script>
-                <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='jquery-ui/jquery-ui.min.js') }}"></script>    <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='colorbox/jquery.colorbox-min.js') }}"></script>
+                <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='colorbox/jquery.colorbox-min.js') }}"></script>
                 <script language="javascript" type="text/javascript" src="{{ url_for('js', filename='js_alt/parsley.min.js') }}"></script>
                 {% block js %}
                 {% endblock %}


### PR DESCRIPTION
#### Description

Bootstrap's tooltip doesn't work as expected because it has a conflict with `jquery-ui`.

An alternative option would be:

- https://stackoverflow.com/a/71176622: create a custom tooltip for bootstrap's and leave the imports as 

TODO:

- @BonfaceKilz let's discuss to see if the unordered imports impact https://github.com/jnduli/genenetwork2/blob/dd7268bc0c2d841779ba488b13ca0b1f0e9ea6bc/gn2/wqflask/templates/case_attributes.html#L117. When I load a corresponding change I get `Internal Server Error`