### PR TITLE
Bug fix on empty datatables

### DIFF
--- a/gn2/wqflask/templates/gsearch_gene.html
+++ b/gn2/wqflask/templates/gsearch_gene.html
@@ -259,7 +259,7 @@
                 {% endif %}
             }
             
-            if traitsJson.length > 0 {
+            if (traitsJson.length > 0) {
               create_table(tableId, traitsJson, columnDefs, tableSettings);
             }
 

--- a/gn2/wqflask/templates/gsearch_gene.html
+++ b/gn2/wqflask/templates/gsearch_gene.html
@@ -258,8 +258,10 @@
                 "scroller": true
                 {% endif %}
             }
-
-            create_table(tableId, traitsJson, columnDefs, tableSettings);
+            
+            if traitsJson.length > 0 {
+              create_table(tableId, traitsJson, columnDefs, tableSettings);
+            }
 
         });
         

--- a/gn2/wqflask/templates/gsearch_gene.html
+++ b/gn2/wqflask/templates/gsearch_gene.html
@@ -261,6 +261,8 @@
             
             if (traitsJson.length > 0) {
               create_table(tableId, traitsJson, columnDefs, tableSettings);
+            } else {
+              $("#" + tableId +" td").replaceWith("<td>No data</td>")
             }
 
         });


### PR DESCRIPTION
# Description
When a search returns 0 results, the console traceback shows a javascript error that we haven't handled. For example, when you visit the console.log of [this page](https://cd.genenetwork.org/gsearch?type=gene&terms=symbol%3Arandomfacts) we see:

```
Uncaught TypeError: i is undefined
    jQuery 13
    loadDataTable https://cd.genenetwork.org/static/new/javascript/create_datatable.js:70
    create_table https://cd.genenetwork.org/static/new/javascript/create_datatable.js:3
    <anonymous> https://cd.genenetwork.org/gsearch?type=gene&terms=symbol:randomfacts:570
    jQuery 13
```

The fix disable the `create_table` function call when we don't have any results.

## Testing

The datatable still works when we have results:

![image](https://github.com/genenetwork/genenetwork2/assets/19635979/541c3ce9-fc1d-4ba5-b1e5-8d4e782b551c)

and when no results exists, we don't get the error now:

![image](https://github.com/genenetwork/genenetwork2/assets/19635979/db49f62c-71a0-4b11-b944-1666e662634e)

## Review Notes

I can also make the change to https://github.com/jnduli/genenetwork2/blob/dd7268bc0c2d841779ba488b13ca0b1f0e9ea6bc/gn2/wqflask/templates/gsearch_pheno.html#L234 but I'm not too sure how to test this
