### PR TITLE
Gn auth setup cleanup

### DIFF
--- a/gn2/default_settings.py
+++ b/gn2/default_settings.py
@@ -42,7 +42,7 @@ GN_PROXY_URL="https://genenetwork.org/gn3-proxy/"
 SQL_URI = "mysql://gn2:mysql_password@localhost/db_webqtl_s"
 SQL_ALCHEMY_POOL_RECYCLE = 3600
 GN_SERVER_URL = "http://localhost:8880/api/" # REST API server
-AUTH_SERVER_URL="http://localhost:9094/"
+AUTH_SERVER_URL="http://localhost:8081/"
 GN2_BASE_URL = "http://genenetwork.org/" # to pick up REST API
 GN2_BRANCH_URL = GN2_BASE_URL
 
@@ -116,6 +116,8 @@ CORRELATION_COMMAND = os.environ["GN2_PROFILE"] + "/bin/correlation_rust"
 
 OAUTH2_CLIENT_ID="0bbfca82-d73f-4bd4-a140-5ae7abb4a64d"
 OAUTH2_CLIENT_SECRET="yadabadaboo"
+AUTH_SERVER_SSL_PUBLIC_KEY = "/absolute/path/to/ssl_public_key.pem"
+SSL_PRIVATE_KEY = "/absolute/path/to/ssl-private-key.pem"
 
 SESSION_TYPE = "redis"
 SESSION_PERMANENT = True

--- a/gn2/wqflask/oauth2/request_utils.py
+++ b/gn2/wqflask/oauth2/request_utils.py
@@ -35,8 +35,10 @@ def process_error(error: Response,
     if error.status_code in range(400, 500):
         try:
             err = error.json()
-            msg = err.get(
-                "error_message", err.get("error_description", f"{error.reason}"))
+            potential_keys = [key for key in err.keys() if key.startswith("error")]
+            msg = f"{error.reason}"
+            if potential_keys:
+                msg = " ; ".join([f"{k}: {err[k]}" for k in potential_keys])
         except simplejson.errors.JSONDecodeError as _jde:
             msg = message
         return {


### PR DESCRIPTION
# Description

1. Add missing configuration to `default_settings.py` file that allows local testing with `gn-auth`
2. Change default port for `gn-auth` in `default_settings.py` to the port mentioned in gn-auth's documentation.
3. Improving getting error messages where we use all strings that start with a `error`. This was caused by `gn-auth` sending in an error with `error` as the key which was not interpreted correctly

## Testing

Before screenshot when attempting to login locally:

![image](https://github.com/user-attachments/assets/06606422-b6d2-4b3b-b215-3c5e922763d8)

After the error message fix:
![image](https://github.com/user-attachments/assets/7b0ffc55-c1e2-47e1-aa65-4279fe2d849c)

