### PR TITLE
Gn2 Fix profiles pages dashboard

### DIFF
--- a/gn2/wqflask/oauth2/ui.py
+++ b/gn2/wqflask/oauth2/ui.py
@@ -1,11 +1,7 @@
 """UI utilities"""
-from flask import session, render_template
-
-from gn2.wqflask.oauth2 import session
+from flask import render_template
 
 from .client import oauth2_get
-from .client import user_logged_in
-from .request_utils import process_error
 
 def render_ui(templatepath: str, **kwargs):
     """Handle repetitive UI rendering stuff."""
@@ -15,8 +11,7 @@ def render_ui(templatepath: str, **kwargs):
                 lambda _err: roles, lambda auth_roles: auth_roles)
     user_privileges = tuple(
         privilege["privilege_id"] for role in roles for privilege in role["privileges"])
-    user_token = session.user_token().either(lambda _err: "", lambda token: token["access_token"])
     kwargs = {
-            **kwargs, "roles": roles, "user_privileges": user_privileges, "bearer_token": user_token
+            **kwargs, "roles": roles, "user_privileges": user_privileges,
     }
     return render_template(templatepath, **kwargs)

--- a/gn2/wqflask/oauth2/ui.py
+++ b/gn2/wqflask/oauth2/ui.py
@@ -1,6 +1,8 @@
 """UI utilities"""
 from flask import session, render_template
 
+from gn2.wqflask.oauth2 import session
+
 from .client import oauth2_get
 from .client import user_logged_in
 from .request_utils import process_error
@@ -13,7 +15,8 @@ def render_ui(templatepath: str, **kwargs):
                 lambda _err: roles, lambda auth_roles: auth_roles)
     user_privileges = tuple(
         privilege["privilege_id"] for role in roles for privilege in role["privileges"])
+    user_token = session.user_token().either(lambda _err: "", lambda token: token["access_token"])
     kwargs = {
-        **kwargs, "roles": roles, "user_privileges": user_privileges
+            **kwargs, "roles": roles, "user_privileges": user_privileges, "bearer_token": user_token
     }
     return render_template(templatepath, **kwargs)

--- a/gn2/wqflask/oauth2/ui.py
+++ b/gn2/wqflask/oauth2/ui.py
@@ -8,8 +8,11 @@ from .request_utils import process_error
 def render_ui(templatepath: str, **kwargs):
     """Handle repetitive UI rendering stuff."""
     roles = kwargs.get("roles", tuple()) # Get roles
+    if not roles:
+        roles = oauth2_get("auth/system/roles").either(
+                lambda _err: roles, lambda auth_roles: auth_roles)
     user_privileges = tuple(
-        privilege for role in roles for privilege in role["privileges"])
+        privilege["privilege_id"] for role in roles for privilege in role["privileges"])
     kwargs = {
         **kwargs, "roles": roles, "user_privileges": user_privileges
     }

--- a/gn2/wqflask/static/new/javascript/auth/search_mrna.js
+++ b/gn2/wqflask/static/new/javascript/auth/search_mrna.js
@@ -15,12 +15,17 @@ function search_mrna() {
     selected = JSON.parse(document.getElementById(
 	"tbl-link").getAttribute("data-datasets"));
     species_name = document.getElementById("txt-species-name").value
+    bearer_token = document.getElementById("bearer_token").value
     search_endpoint = "/auth/data/mrna/search"
     search_table = new TableDataSource(
 	"#tbl-search", "data-datasets", search_checkbox);
     $.ajax(
 	form.action,
 	{
+
+	    "beforeSend": function (xhr) {
+		xhr.setRequestHeader('Authorization', 'Bearer ' + bearer_token);
+	    },
 	    "method": "POST",
 	    "contentType": "application/json; charset=utf-8",
 	    "dataType": "json",

--- a/gn2/wqflask/static/new/javascript/auth/search_mrna.js
+++ b/gn2/wqflask/static/new/javascript/auth/search_mrna.js
@@ -15,17 +15,12 @@ function search_mrna() {
     selected = JSON.parse(document.getElementById(
 	"tbl-link").getAttribute("data-datasets"));
     species_name = document.getElementById("txt-species-name").value
-    bearer_token = document.getElementById("bearer_token").value
     search_endpoint = "/auth/data/mrna/search"
     search_table = new TableDataSource(
 	"#tbl-search", "data-datasets", search_checkbox);
     $.ajax(
 	form.action,
 	{
-
-	    "beforeSend": function (xhr) {
-		xhr.setRequestHeader('Authorization', 'Bearer ' + bearer_token);
-	    },
 	    "method": "POST",
 	    "contentType": "application/json; charset=utf-8",
 	    "dataType": "json",

--- a/gn2/wqflask/templates/oauth2/data-list-mrna.html
+++ b/gn2/wqflask/templates/oauth2/data-list-mrna.html
@@ -92,11 +92,9 @@
   <div class="row">
     <span id="search-messages" class="alert-danger" style="display:none"></span>
     <form id="frm-search"
-	  action="{{search_uri}}"
+	  action="{{url_for('oauth2.data.json_search_mrna')}}"
 	  method="POST">
       <legend>Search: mRNA Assay</legend>
-
-      <input type="hidden" id="bearer_token" name="bearer_token" value="{{bearer_token}}" />
       <input type="hidden" value="{{species_name}}" name="species"
 	     id="txt-species-name" />
       <input type="hidden" value="{{dataset_type}}" name="dataset_type"

--- a/gn2/wqflask/templates/oauth2/data-list-mrna.html
+++ b/gn2/wqflask/templates/oauth2/data-list-mrna.html
@@ -95,6 +95,8 @@
 	  action="{{search_uri}}"
 	  method="POST">
       <legend>Search: mRNA Assay</legend>
+
+      <input type="hidden" id="bearer_token" name="bearer_token" value="{{bearer_token}}" />
       <input type="hidden" value="{{species_name}}" name="species"
 	     id="txt-species-name" />
       <input type="hidden" value="{{dataset_type}}" name="dataset_type"


### PR DESCRIPTION
# Description
we have some bugs related to the profiles dashboard fixed here:

1. We don't correcly pass in the list of privileges so the [jinja templates checks](https://github.com/jnduli/genenetwork2/blob/dd7268bc0c2d841779ba488b13ca0b1f0e9ea6bc/gn2/wqflask/templates/oauth2/profile_nav.html#L26) for these will always fail
2. Searching for data to link queries gn-auth, but we don't pass in a token, resulting in a failure during search.

## Tested

`Linked Data` and `Masquerade As` are not visible in profiles page:
![image](https://github.com/user-attachments/assets/453cf0d4-f5ae-46c4-a316-0e4d8a7c9918)

Seach now works in the `Link mrna page`:
![image](https://github.com/user-attachments/assets/20535b1c-1b13-4ada-8ba1-453dd3bde5e6)


