### PR TITLE
Add a page for searching GeneWiki by symbol.

### DIFF
--- a/gn2/wqflask/templates/wiki/search.html
+++ b/gn2/wqflask/templates/wiki/search.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block content %}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-9 col-md-offset-3">
+                <h1>
+                    <strong>GeneWiki Entries</strong>
+                </h1>
+                <p>
+                    GeneWiki enables you to enrich the annotation of genes and transcripts. Please submit or edit a GeneWiki note (500 characters max) related to a gene, its transcripts, or proteins. When possible include PubMed identifiers or web resource links (URL addresses). Please ensure that the additions will have widespread use. For additional information, check the GeneWiki <a href="https://gn1.genenetwork.org/GeneWikihelp.html" target="_blank">help document</a>.
+                </p>
+                <span id="helpBlock" class="help-block">Please enter a gene symbol in the box below and then click submit.</span>
+            </div>
+        </div>
+        <div class="row">
+            <form method="POST"
+                  class="form-inline col-md-9 col-md-offset-3"
+                  action="{{ url_for("search_wiki") }}">
+                <div class="form-group col-md-offset-2">
+                    <label for="search" class="sr-only">Search Symbol</label>
+                    <input name="search"
+                           type="text"
+                           class="form-control"
+                           id="search"
+                           placeholder="Search Symbol"
+                           aria-describeBy="helpBlock" />
+                </div>
+                <button type="submit" class="btn btn-primary">submit</button>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/gn2/wqflask/views.py
+++ b/gn2/wqflask/views.py
@@ -1599,3 +1599,15 @@ def edit_wiki(comment_id: int):
 
         flash(f"Success: {post_res}", "alert-success")
         return redirect(url_for("edit_wiki", comment_id=comment_id))
+
+
+@app.route("/genewiki", methods=["POST", "GET"])
+def search_wiki():
+    """Search genewiki for a given symbol"""
+    if request.method == "GET":
+        return render_template(
+            "wiki/search.html",
+        )
+    return redirect(url_for(
+        "display_genewiki_page",
+        symbol=request.form.get("search")))


### PR DESCRIPTION
### Description

This is a replica of [this](https://gn1.genenetwork.org/webqtl/main.py?FormID=geneWiki) page in GN1 retaining the same functionality.

GN1:

![image](https://github.com/user-attachments/assets/a2d9f793-3640-4fbb-bf44-0d2fa26694db)

GN2:

![image](https://github.com/user-attachments/assets/071affa3-0cfe-486a-977b-40c7558b17b7)


