### PR TITLE
Llm integration bug fix

### DIFF
--- a/gn2/wqflask/templates/gnqa.html
+++ b/gn2/wqflask/templates/gnqa.html
@@ -80,10 +80,15 @@
      background-color: #ccf;
  }
 
+.linux-libertine-font{
+    font-family: 'Linux Libertine','Georgia','Times','Source Serif Pro', 'serif'
+}
+
     </style>
 {% endblock %}
 {% block search %}{% endblock %}
 {% block content %}
+
     <!-- Start of body -->
     <section class="container-fluid">
         <header class="row">
@@ -119,39 +124,44 @@
                        autocomplete="on"
                        required
                        placeholder="Ask More Questions or Topics (E.g Genes)"
+                       {% if query %}
+                       value='{{ query }}'
+                       {% else %}
                        value=''
+                       {% endif %}
                        name="querygnqa" />
             </div>
         </form>
         <article id="swap" class="row">
-            <div class="row gnqa-copy">
-                <div class="col-sm-10 col-sm-offset-1 col-md-offset-3 col-md-6">
-                    <p>
-                        Welcome to the GeneNetwork Question and Answer (GNQA)system. We utilize a large language model and 3000 scientific publications to make GNQA a subject matter expert in three areas: <b><a href="/">GeneNetwork.org</a></b>, <b>genomics/genetics with regards to diabetes</b> and <b>genomics/genetics with regards to agin.</b>.
-                    </p>
-                    <p>
-                        At the moment when you ask GNQA something it will attempt to return a sensible answer with <q>real</q> references. To this end we aim to reduce hallucinations and provide a knowledge launchpad for a researcher to enhance their knowledge on the relevant subject matter.
-                    </p>
-                    <p>GNQA is not a finished product as we are working diligently to improve it daily.</p>
-                    <p>
-                        <b>Thanks for using GNQA!</b>
-                    </p>
-                    <div></div>
-                </article>
-            </section>
-        {% endblock %}
-        {% block js %}
-            <script src="{{ url_for('js', filename='jquery/jquery.min.js') }}"
-                    type="text/javascript"></script>
-            <script language="javascript"
-                    type="text/javascript"
-                    src="{{ url_for('js', filename='jquery-ui/jquery-ui.min.js') }}"></script>
-            <script language="javascript"
-                    type="text/javascript"
-                    src="{{ url_for('js', filename='htmx.min.js') }}"></script>
-            <script type="text/javascript">
- document.addEventListener('DOMContentLoaded', function() {
-     $('footer').hide()
- });
-            </script>
-        {% endblock %}
+            {% if answer %}
+                {% include 'gnqa_answer.html' %}
+            {% else %}
+
+                <div class="row gnqa-copy">
+                    <div class="col-sm-10 col-sm-offset-1 col-md-offset-3 col-md-6">
+                        <p>
+                            Welcome to the GeneNetwork Question and Answer (GNQA)system. We utilize a large language model and 3000 scientific publications to make GNQA a subject matter expert in three areas: <b><a href="/">GeneNetwork.org</a></b>, <b>genomics/genetics with regards to diabetes</b> and <b>genomics/genetics with regards to agin.</b>.
+                        </p>
+                        <p>
+                            At the moment when you ask GNQA something it will attempt to return a sensible answer with <q>real</q> references. To this end we aim to reduce hallucinations and provide a knowledge launchpad for a researcher to enhance their knowledge on the relevant subject matter.
+                        </p>
+                        <p>GNQA is not a finished product as we are working diligently to improve it daily.</p>
+                        <p>
+                            <b>Thanks for using GNQA!</b>
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
+        </article>
+    </section>
+    {% endblock %}
+    {% block js %}
+        <script src="{{ url_for('js', filename='jquery/jquery.min.js') }}" type="text/javascript"></script>
+        <script src="{{ url_for('js', filename='jquery-ui/jquery-ui.min.js') }}" type="text/javascript"></script>
+        <script src="{{ url_for('js', filename='htmx.min.js') }}" type="text/javascript" ></script>
+        <script type="text/javascript">
+document.addEventListener('DOMContentLoaded', function() {
+ $('footer').hide()
+});
+        </script>
+    {% endblock %}

--- a/gn2/wqflask/templates/gnqa_answer.html
+++ b/gn2/wqflask/templates/gnqa_answer.html
@@ -1,15 +1,3 @@
-{% extends "base.html" %}
-
-{% block css %}
-<style>
-.linux-libertine-font{
-    font-family: 'Linux Libertine','Georgia','Times','Source Serif Pro', 'serif'
-}
-</style>
-{% endblock %}
-
-{% block content %}
-<br/>
 <section class="container-fluid answers gnqa-copy">
     <div class="row container gnqa-answer" style="margin-bottom: 1em">
         <p class="row lead">
@@ -155,9 +143,9 @@
         </div>
     </div>
 </section>
-{% endblock %}
-{% block js %}
-    <script>
+
+<script>
+$(document).ready(function() {
   function updateRatingHandler(target, responseObj, args){
     let {status, response} = responseObj.xhr
     if (status == 200 && args == "upvote"){
@@ -189,5 +177,5 @@ htmx.on("#upvote", "click", function(evt){
 		 handler: (target, obj)=> updateRatingHandler(target,obj, "downvote"),
 		 swap:"innerHTML",
 		 values: {'query': query, 'answer': answer}})});
-    </script>
-{% endblock %}
+})
+</script>

--- a/gn2/wqflask/templates/gnqa_answer.html
+++ b/gn2/wqflask/templates/gnqa_answer.html
@@ -1,7 +1,19 @@
+{% extends "base.html" %}
+
+{% block css %}
+<style>
+.linux-libertine-font{
+    font-family: 'Linux Libertine','Georgia','Times','Source Serif Pro', 'serif'
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<br/>
 <section class="container-fluid answers gnqa-copy">
     <div class="row container gnqa-answer" style="margin-bottom: 1em">
         <p class="row lead">
-            <mark style="font-family: 'Linux Libertine','Georgia','Times','Source Serif Pro',serif"><b><i>{{ query }}</i></b></mark>
+            <mark class="linux-libertine-font"><b><i>{{ query }}</i></b></mark>
             <br />
             <span  style="white-space: pre-line">{{ answer|safe }}</span>
         </p>
@@ -20,32 +32,24 @@
                     title="Vote Down">
                 <i class="fa fa-thumbs-down fa-sm fa-1x" aria-hidden="true"></i>
             </button>
-            <sub id="rate" class="text-info">
-            </sub>
+            <sub id="rate" class="text-info"></sub>
         </div>
     </div>
     <div class="row container">
         <details open>
             <summary>
-                <h3 style="font-family: 'Linux Libertine','Georgia','Times','Source Serif Pro',serif">References</h3>
+                <h3 class="linux-libertine-font">References</h3>
             </summary>
             {% if references %}
                 <ul class="list-unstyled">
                     {% for reference in references %}
                         <li>
-                            <div class="panel-group"
-                                 role="tablist"
-                                 aria-multiselectable="true"
-                                 style="margin-bottom:0">
+                            <div class="panel-group" role="tablist" aria-multiselectable="true" style="margin-bottom:0">
                                 <div class="panel panel-default">
                                     {% if loop.first %}
-                                        <div class="panel-heading active"
-                                             role="tab"
-                                             id="heading{{ reference.doc_id }}">
-                                            <h4 class="panel-title"
-                                                style="font-family: 'Linux Libertine','Georgia','Times','Source Serif Pro',serif">
-                                                <a class="collapsed"
-                                                   role="button"
+                                        <div class="panel-heading active" role="tab" id="heading{{ reference.doc_id }}">
+                                            <h4 class="panel-title linux-libertine-font">
+                                                <a class="collapsed" role="button"
                                                    data-toggle="collapse"
                                                    data-parent="#accordion"
                                                    href="#collapse{{ reference.doc_id }}"
@@ -65,8 +69,7 @@
                                                     {% if reference.pubmed %}
                                                         <details open>
                                                             <summary>See PubMed Info</summary>
-                                                            <div style="font-family: 'Linux Libertine','Georgia','Times','Source Serif Pro',serif;
-                                                                        margin-top:1.4em">
+                                                            <div class="linux-libertine-font" style="margin-top:1.4em">
                                                                 <h3>
                                                                     <b>{{ reference.pubmed[0].get("title") }}:</b>
                                                                 </h3>
@@ -90,8 +93,7 @@
                                             </div>
                                         {% else %}
                                             <div class="panel-heading" role="tab" id="heading{{ reference.doc_id }}">
-                                                <h4 class="panel-title"
-                                                    style="font-family: 'Linux Libertine','Georgia','Times','Source Serif Pro',serif">
+                                                <h4 class="panel-title linux-libertine-font">
                                                     <a class="collapsed"
                                                        role="button"
                                                        data-toggle="collapse"
@@ -113,8 +115,7 @@
                                                         {% if reference.pubmed %}
                                                             <details>
                                                                 <summary>See PubMed Info</summary>
-                                                                <div style="font-family: 'Linux Libertine','Georgia','Times','Source Serif Pro',serif;
-                                                                            margin-top:1.4em">
+                                                                <div class="linux-libertine-font" style="margin-top:1.4em">
                                                                     <h3>
                                                                         <b>{{ reference.pubmed[0].get("title") }}:</b>
                                                                     </h3>
@@ -154,6 +155,7 @@
         </div>
     </div>
 </section>
+{% endblock %}
 {% block js %}
     <script>
   function updateRatingHandler(target, responseObj, args){

--- a/gn2/wqflask/templates/gsearch_gene.html
+++ b/gn2/wqflask/templates/gsearch_gene.html
@@ -16,8 +16,14 @@
         </h3>
       </div>
 
+
+      {% if do_ai_search %}
       <div class="row" id="ai_result">
+        <div class="text-center" id="spinner">
+           <i class="fa fa-spinner fa-spin fa-3x"></i>
+        </div>
       </div>
+      {% endif %}
 
         <p>To study a record, click on its Record ID below.<br />Check records below and click Add button to add to selection.</p>
         <div>
@@ -306,6 +312,9 @@
           success: function(result) {
             let ai_div = ai_content_div(result.search_term, result.search_result, result.search_url)
             $("#ai_result").append(ai_div);
+          },
+          complete: function() {
+            $("#spinner").hide();
           }
         })
       })

--- a/gn2/wqflask/views.py
+++ b/gn2/wqflask/views.py
@@ -324,7 +324,7 @@ def gnqna():
                     "search_url": f"/gnqna?{safe_query}",
                 }
                 return jsonify(ai_result)
-            return render_template("gnqa_answer.html", **search_result)
+            return render_template("gnqa.html", **search_result)
         else:
             return render_template("gnqa.html")
     if request.method == "POST":

--- a/gn2/wqflask/views.py
+++ b/gn2/wqflask/views.py
@@ -270,9 +270,21 @@ def gsearchtable():
 
 def clean_xapian_query(query: str) -> str:
     """ Remove filler words in xapian query
+    This is a temporary solution that works for some query. A better solution is being worked on.
     TODO: FIXME
     """
-    return query
+    xapian_prefixes = set(["author", "species", "group", "tissue", "dataset", "symbol", "description", "rif", "wiki"])
+    range_prefixes = set(["mean", "peak", "position", "peakmb", "additive", "year"])
+    final_query = []
+    for word in query.split():
+        split_word = word.split(":")
+        if len(split_word) > 0 and split_word[0].lower() in xapian_prefixes:
+            final_query.append(split_word[1])
+            continue
+        if split_word[0].lower() in range_prefixes:
+            # no need to search for ranges
+            continue
+    return " ".join(final_query)
 
 
 @app.route("/gnqna", methods=["POST", "GET"])

--- a/gn2/wqflask/views.py
+++ b/gn2/wqflask/views.py
@@ -299,7 +299,7 @@ def gnqna():
             if query_type == "xapian":
                 query = clean_xapian_query(query)
             safe_query = urllib.parse.urlencode({"query": query})
-            search_result = requests.put(
+            search_result = requests.get(
                 urljoin(GN3_LOCAL_URL, f"/api/llm/search?{safe_query}"),
                 headers={"Authorization": f"Bearer {token}"},
             )


### PR DESCRIPTION
# Description

Bug fixes for LLM integration work that includes:

- ensure `gnqa_answers` jinja templates extends `base.html`
- send `get` request instead of `put` when accessing gn3's llm search api
- provide a rough implementation for the `xapian_query_cleaner` implementation.
- add a spinner when api search is happening

# Tested

Results after search screenshot:
![image](https://github.com/user-attachments/assets/26d9befb-ca13-4b95-8c0c-033f97095288)

And the ai results page:
![image](https://github.com/user-attachments/assets/35b028af-bff9-4ea8-b04f-96190fedb399)
