### PR TITLE
feat: improve animations text in llm search integration

### DIFF
--- a/gn2/wqflask/templates/gsearch_gene.html
+++ b/gn2/wqflask/templates/gsearch_gene.html
@@ -18,7 +18,7 @@
 
 
       {% if do_ai_search %}
-      <div class="row" id="ai_result">
+      <div class="row" id="ai_result_info">
         <div class="text-center" id="spinner">
            <i class="fa fa-spinner fa-spin fa-3x"></i>
         </div>
@@ -287,13 +287,14 @@
     {% if do_ai_search %}
     <script type='text/javascript'>
       function ai_content_div(search_term, search_result, search_uri) {
+        let header = search_result.slice(0, 75);
         return `
           <div class="col-sm-6">
             <div class="panel panel-info">
               <div class="panel-heading" role="tab" id="ai_heading">
                 <h4 class="panel-title">
-                  <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#ai_results" aria-expanded="false" aria-controls="ai_results">
-                    AI Search: ${search_term} (Click for more details)
+                  <a id="panel-title-content" class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#ai_results" aria-expanded="false" aria-controls="ai_results">
+                    ${header}... (Click for more details)
                   </a>
                 </h4>
               </div>
@@ -308,6 +309,20 @@
           `
       }
 
+      $('#ai_result_info').on('hidden.bs.collapse', function () {
+        let original_text = $("#panel-title-content").text();
+        let new_text = original_text.replace("(Click to fold)", "(Click for more details)");
+        $("#panel-title-content").text(new_text);
+      })
+
+      $('#ai_result_info').on('shown.bs.collapse', function () {
+        let original_text = $("#panel-title-content").text();
+        let new_text = original_text.replace("(Click for more details)", "(Click to fold)");
+        $("#panel-title-content").text(new_text);
+      })
+
+
+
       $(document).ready( function () {
         $.ajax({url: "gnqna",
           contentType: "application/json",
@@ -317,7 +332,7 @@
           },
           success: function(result) {
             let ai_div = ai_content_div(result.search_term, result.search_result, result.search_url)
-            $("#ai_result").append(ai_div);
+            $("#ai_result_info").append(ai_div);
           },
           complete: function() {
             $("#spinner").hide();

--- a/gn2/wqflask/templates/gsearch_gene.html
+++ b/gn2/wqflask/templates/gsearch_gene.html
@@ -287,14 +287,29 @@
     {% if do_ai_search %}
     <script type='text/javascript'>
       function ai_content_div(search_term, search_result, search_uri) {
-        let header = search_result.slice(0, 75);
+        let header_length = 40;
+        let max_header_length = 180;
+        while (header_length <= search_result.length) {
+          let next_dot = search_result.indexOf(".", header_length+1);
+
+          if (next_dot > max_header_length) {
+            let next_comma = search_result.indexOf(",", header_length+1);
+            if (next_comma > max_header_length) {
+              break;
+            }
+            header_length = next_comma;
+          } else {
+            header_length = next_dot;
+          }
+        }
+        let header = search_result.slice(0, header_length+1);
         return `
           <div class="col-sm-6">
             <div class="panel panel-info">
               <div class="panel-heading" role="tab" id="ai_heading">
                 <h4 class="panel-title">
                   <a id="panel-title-content" class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#ai_results" aria-expanded="false" aria-controls="ai_results">
-                    ${header}... (Click for more details)
+                    ${header} ... (Click for more details)
                   </a>
                 </h4>
               </div>


### PR DESCRIPTION
#### Description
UI improvements for LLM integration:

1. Show part of the context message in search instead of the `search term`
2. Change text to `Click to fold` when the full context is shown

Screenshots:

With context not shown:
![image](https://github.com/user-attachments/assets/e7820ee5-60f0-4a4c-8186-757bc0fc9114)

With context shown:
![image](https://github.com/user-attachments/assets/334100dc-8fd0-461e-be05-96ece8bb477d)

Change to include full sentences in summary context:
![image](https://github.com/user-attachments/assets/af759e32-06a5-4380-82cf-21e697955de9)
