### PR TITLE
Correctly handle 404 empty data errors from gn3 wiki/rif API.

### DIFF
--- a/gn2/wqflask/views.py
+++ b/gn2/wqflask/views.py
@@ -1312,13 +1312,21 @@ def display_genewiki_page(symbol: str):
     try:
         wiki = requests.get(
             urljoin(GN3_LOCAL_URL, f"/api/metadata/wiki/{symbol}"))
-        rif = requests.get(
-            urljoin(GN3_LOCAL_URL, f"/api/metadata/rif/{symbol}"))
         wiki.raise_for_status()
-        rif.raise_for_status()
-        wiki, rif = wiki.json(), rif.json()
+        wiki = wiki.json()
+    except requests.exceptions.HTTPError as excp:
+        wiki = {}
     except requests.RequestException as excp:
         flash(excp, "alert-warning")
+    try:
+        rif = requests.get(
+            urljoin(GN3_LOCAL_URL, f"/api/metadata/rif/{symbol}"))
+        rif.raise_for_status()
+        rif = rif.json()
+    except requests.RequestException as excp:
+        flash(excp, "alert-warning")
+    except requests.exceptions.HTTPError as excp:
+        rif = {}
     sess_info = session_info()
     is_logged_in = sess_info.get("user", {}).get("logged_in", False)
     return render_template("wiki/genewiki.html",


### PR DESCRIPTION
# Description

Error in production:

![image](https://github.com/user-attachments/assets/3f14a0be-1ad5-4fdc-a5fb-0a7dea224cec)

When going to: https://genenetwork.org/genewiki/Eif2ak2

# Resolution

For empty data in gn3, for empty data, we [correctly](https://stackoverflow.com/questions/11746894/what-is-the-proper-rest-response-code-for-a-valid-request-but-empty-data) return a 404.  However in gn2, we don't handle this exception.
