### PR TITLE
Center genewiki search page.

### DIFF
--- a/gn2/wqflask/templates/wiki/search.html
+++ b/gn2/wqflask/templates/wiki/search.html
@@ -1,8 +1,17 @@
 {% extends "index_page.html" %}
+{%block css%}
+<style>
+ .col-centered{
+     float: none;
+     margin: 0 auto;
+ }
+</style>
+{%endblock%}
+
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-md-9 col-md-offset-3">
+            <div class="col-lg-8 col-centered">
                 <h1>
                     <strong>GeneWiki Entries</strong>
                 </h1>
@@ -14,7 +23,7 @@
         </div>
         <div class="row">
             <form method="POST"
-                  class="form-inline col-md-9 col-md-offset-3"
+                  class="form-inline col-md-9 col-centered"
                   action="{{ url_for("search_wiki") }}">
                 <div class="form-group col-md-offset-2">
                     <label for="search" class="sr-only">Search Symbol</label>


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->
Simple UI fix that *properly* centers the genewiki [search page](https://cd.genenetwork.org/genewiki):

![image](https://github.com/user-attachments/assets/bdc7bc6e-e1a1-425c-b3f6-739adf7297e5)

To:
![image](https://github.com/user-attachments/assets/b26555a9-7685-4e68-9d00-3b3ec8237e8b)
