### PR TITLE
Left align wiki pages

### DIFF
--- a/gn2/wqflask/__init__.py
+++ b/gn2/wqflask/__init__.py
@@ -111,6 +111,8 @@ app.jinja_env.globals.update(
     num_collections=numcoll,
     datetime=datetime)
 
+app.url_map.strict_slashes = False
+
 
 # Registering blueprints
 app.register_blueprint(gn_docs_blueprint, url_prefix="/gn-docs")

--- a/gn2/wqflask/templates/wiki/edit_wiki.html
+++ b/gn2/wqflask/templates/wiki/edit_wiki.html
@@ -1,125 +1,127 @@
 {% extends "index_page.html" %}
-
 {% block css %}
-<style>
- .panel {
-     width: 90%;
-     margin: 2em;
- }
- .container {
-     align-content: center;
- }
+    <style>
+        .wiki-btns {
+            margin-top: 5em;
+        }
 
- .wiki-btns {
-     margin-top: 5em;
- }
-
- .wiki-btns button:first-child {
-     margin-right: 1em;
- }
-
- .wiki {
-     width: fit-content;
- }
-</style>
+        .wiki-btns button:first-child {
+            margin-right: 1em;
+            margin-left: 1em;
+        }
+    </style>
 {% endblock %}
-
 {% block content %}
-
-{{ flash_me() }}
-<section class="container">
-    <div class="row wiki-form">
-	<div class="wiki col-centered">
-	    <h1>
-		{% if last_wiki_content %}
-		Add GeneWiki Entry
-		{% else %}
-		Edit Wiki
-		{% endif %}
-
-		{% if content["symbol"] %}
-                for {{ content["symbol"] }}
-		{% endif %}
-	    </h1>
-	    <br>
-	    <form class="form-horizontal" method="POST">
-		<input type="hidden" name="symbol" value="{{ content["symbol"] }}">
-		{% if last_wiki_content %}
-		<div class="form-group">
-		    <label for="reason" class="col-sm-2">Reason for Modification: </label>
-		    <input type="text" name="reason" size=45 maxlength=100 required>
-		</div>
-		{% endif %}
-		<div class="form-group">
-		    <label for="species" class="col-sm-2">Species: </label>
-		    <select name="species" id="species">
-			{% for name, species_name in species_dict.items() %}
-			    {% if name == content["species"] %}
-			    <option selected="selected" value="{{ name }}">{{ species_name }}</option>
-			    {% else %}
-			    <option value="{{ name }}">{{ species_name }}</option>
-			    {% endif %}
-			{% endfor %}
-		    </select>
-		</div>
-		<div class="form-group">
-		    <label for="pubmed_ids" class="col-sm-2">PubMed IDS: </label>
-		    <input type="text" name="pubmed_ids" size=25 maxlength=25 value="{{ " ".join(content["pubmed_ids"]) }}">
-		    (optional, separate by blank space only)
-		</div>
-		<div class="form-group">
-		    <label for="web_url" class="col-sm-2">Web resource URL: </label>
-		    {% if content["weburl"] %}
-		    <input type="text" name="web_url" value="{{ content["weburl"] }}" size=50 maxlength=255>
-		    {% else %}
-		    <input type="text" name="web_url" value="http://" size=50 maxlength=255>
-		    {% endif %}
-		    (optional)
-		</div>
-		<div class="form-group">
-		    <label for="comment" class="col-sm-2">Text: </label>
-		    <textarea name="comment" rows=5 cols=60 required>{{ content["comment"] }}</textarea>
-		</div>
-		<div class="form-group">
-		    <label for="email" class="col-sm-2">Email: </label>
-		    <input type="text" name="email" value="{{ session_email }}" required>
-		</div>
-		<div class="form-group">
-		    <label for="usercode" class="col-sm-2">User Code: </label>
-		    <input type="text" name="initial" value="{{ content["initial"] }}"/>
-		    (optional user or project code or your initials)
-		</div>
-		<div class="form-group">
-		    <label class="col-sm-2">Category of Gene<br>(Please select one or <br>many categories): </label>
-		    <div class="col-sm-10">
-		    {% for group in grouped_categories %}
-		    <div class="row">
-		    {% for cat in group %}
-			<label class="checkbox-inline col-sm-3">
-			    {% if cat in content["categories"] %}
-			    <input checked type="checkbox" name="genecategory" value="{{ cat }}"> {{ cat }}
-			    {% else %}
-			    <input type="checkbox" name="genecategory" value="{{ cat }} "> {{ cat }}
-			    {% endif %}
-			</label>
-		    {% endfor %}
-		    </div>
-		    {% endfor %}
-		    </div>
-		    <div class="row wiki-btns">
-			<div class="col-md-3 form-group col-centered">
-			    <button type="submit" name="submit" class="btn btn-lg btn-primary">
-				{% if last_wiki_content %}
-				Update
-				{% else %}
-				Create
-				{% endif %}
-				GeneWiki Entry
-			    </button>
-			    <button type="reset" name="rest" class="btn btn-lg btn-secondary" onClick="window.location.reload();">Reset</button>
-			</div>
-		    </div>
-	    </form>
-	</div>
-	</div>
+    {{ flash_me() }}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-12">
+                <h1>
+                    {% if last_wiki_content %}
+                        Add GeneWiki Entry
+                    {% else %}
+                        Edit Wiki
+                    {% endif %}
+                    {% if content["symbol"] %}for {{ content["symbol"] }}{% endif %}
+                </h1>
+                <br />
+                <form class="form-horizontal" method="POST">
+                    <input type="hidden" name="symbol" value="{{ content["symbol"] }}">
+                    {% if last_wiki_content %}
+                        <div class="form-group">
+                            <label for="reason" class="col-sm-2">Reason for Modification:</label>
+                            <input type="text" name="reason" size=45 maxlength=100 required>
+                        </div>
+                    {% endif %}
+                    <div class="form-group">
+                        <label for="species" class="col-sm-2">Species:</label>
+                        <select name="species" id="species">
+                            {% for name, species_name in species_dict.items() %}
+                                {% if name == content["species"] %}
+                                    <option selected="selected" value="{{ name }}">{{ species_name }}</option>
+                                {% else %}
+                                    <option value="{{ name }}">{{ species_name }}</option>
+                                {% endif %}
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="pubmed_ids" class="col-sm-2">PubMed IDS:</label>
+                        <input type="text"
+                               name="pubmed_ids"
+                               size="25"
+                               maxlength="25"
+                               value="{{ " ".join(content["pubmed_ids"]) }}">
+                        (optional, separate by blank space only)
+                    </div>
+                    <div class="form-group">
+                        <label for="web_url" class="col-sm-2">Web resource URL:</label>
+                        {% if content["weburl"] %}
+                            <input type="text"
+                                   name="web_url"
+                                   value="{{ content["weburl"] }}"
+                                   size="50"
+                                   maxlength="255">
+                        {% else %}
+                            <input type="text" name="web_url" value="http://" size=50 maxlength=255>
+                        {% endif %}
+                        (optional)
+                    </div>
+                    <div class="form-group">
+                        <label for="comment" class="col-sm-2">Text:</label>
+                        <textarea name="comment" rows=5 cols=60 required>{{ content["comment"] }}</textarea>
+                    </div>
+                    <div class="form-group">
+                        <label for="email" class="col-sm-2">Email:</label>
+                        <input type="text" name="email" value="{{ session_email }}" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="usercode" class="col-sm-2">User Code:</label>
+                        <input type="text" name="initial" value="{{ content["initial"] }}" />
+                        (optional user or project code or your initials)
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-2">
+                            Category of Gene
+                            <br>
+                            (Please select one or
+                            <br>
+                            many categories):
+                        </label>
+                        <div class="col-sm-10">
+                            {% for group in grouped_categories %}
+                                <div class="row">
+                                    {% for cat in group %}
+                                        <label class="checkbox-inline col-sm-3">
+                                            {% if cat in content["categories"] %}
+                                                <input checked type="checkbox" name="genecategory" value="{{ cat }}">
+                                                {{ cat }}
+                                            {% else %}
+                                                <input type="checkbox" name="genecategory" value="{{ cat }} ">
+                                                {{ cat }}
+                                            {% endif %}
+                                        </label>
+                                    {% endfor %}
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="form-group wiki-btns">
+                        <button type="submit" name="submit" class="btn btn-lg btn-primary">
+                            {% if last_wiki_content %}
+                                Update
+                            {% else %}
+                                Create
+                            {% endif %}
+                            GeneWiki Entry
+                        </button>
+                        <button type="reset"
+                                name="rest"
+                                class="btn btn-lg btn-secondary"
+                                onClick="window.location.reload();">Reset</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
 {% endblock %}

--- a/gn2/wqflask/templates/wiki/genewiki.html
+++ b/gn2/wqflask/templates/wiki/genewiki.html
@@ -7,13 +7,13 @@
         <p>
             GeneWiki enables you to enrich the annotation of genes and transcripts. Please submit or edit a GeneWiki note (500 characters max) related to a gene, its transcripts, or proteins. When possible include PubMed identifiers or web resource links (URL addresses). Please ensure that the additions will have widespread use. For additional information, check the GeneWiki <a href="https://gn1.genenetwork.org/GeneWikihelp.html" target="_blank">help document</a>.
         </p>
-        <h3>GeneWiki For {{ symbol }}:
-	    {% if is_logged_in and wiki %}
-	    <a href="{{ url_for('edit_wiki', symbol=symbol) }}" class="btn btn-primary">
-		New GeneWiki Entry
-	    </a>
-	    {% endif %}
-	</h3>
+        <h3>
+            GeneWiki For {{ symbol }}:
+            {% if is_logged_in and wiki %}
+                <a href="{{ url_for('edit_wiki', symbol=symbol) }}"
+                   class="btn btn-primary">New GeneWiki Entry</a>
+            {% endif %}
+        </h3>
         <h5>
             <strong>GeneNetwork:</strong>
         </h5>
@@ -30,21 +30,20 @@
                             </div>
                             <div class="col-sm-2">
                                 {% if is_logged_in %}
-                                <a href="{{ url_for('edit_wiki', comment_id=entry['id']) }}">
-                                    <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-                                </a>
+                                    <a href="{{ url_for('edit_wiki', comment_id=entry['id']) }}">
+                                        <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+                                    </a>
                                 {% else %}
-                                <a data-toggle="collapse" data-target="#collapseLogin{{ loop.index }}" aria-expanded="false" aria-controls="collapseLogin{{ loop.index }}">
-                                    <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-                                </a>
-
-                                <div class="collapse" id="collapseLogin{{ loop.index }}">
-                                  <div class="well">
-                                      Please login to be able to edit this
-                                  </div>
-                                </div>
+                                    <a data-toggle="collapse"
+                                       data-target="#collapseLogin{{ loop.index }}"
+                                       aria-expanded="false"
+                                       aria-controls="collapseLogin{{ loop.index }}">
+                                        <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
+                                    </a>
+                                    <div class="collapse" id="collapseLogin{{ loop.index }}">
+                                        <div class="well">Please login to be able to edit this</div>
+                                    </div>
                                 {% endif %}
-
                                 <sup><small>[<a href="/genewiki/{{ entry.id }}/history" target="_blank">history</a>]</small></sup>
                             </div>
                         </div>
@@ -53,13 +52,14 @@
             </ol>
         {% else %}
             <p class = "well">
-                <u> There are no GeneNetwork entries for <b> {{ symbol }}.</b></u><br/>
-		Consider adding new gene entries: <br/>
-		{% if is_logged_in %}
-		<a href="{{ url_for('edit_wiki', symbol=symbol) }}" class="btn btn-primary">
-		    New GeneWiki Entry
-		</a>
-		{% endif %}
+                <u> There are no GeneNetwork entries for <b> {{ symbol }}.</b></u>
+                <br />
+                Consider adding new gene entries:
+                <br />
+                {% if is_logged_in %}
+                    <a href="{{ url_for('edit_wiki', symbol=symbol) }}"
+                       class="btn btn-primary">New GeneWiki Entry</a>
+                {% endif %}
             </p>
         {% endif %}
         <h5>

--- a/gn2/wqflask/templates/wiki/search.html
+++ b/gn2/wqflask/templates/wiki/search.html
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-lg-8 col-centered">
+            <div class="col-lg-8">
                 <h1>
                     <strong>GeneWiki Entries</strong>
                 </h1>
@@ -15,9 +15,9 @@
         </div>
         <div class="row">
             <form method="POST"
-                  class="form-inline col-md-9 col-centered"
+                  class="form-inline col-md-9"
                   action="{{ url_for("search_wiki") }}">
-                <div class="form-group col-md-offset-2">
+                <div class="form-group">
                     <label for="search" class="sr-only">Search Symbol</label>
                     <input name="search"
                            type="text"


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->
This PR:
- Disables strict trailing slashes.  So now: https://cd.genenetwork.org/genewiki/ and https://cd.genenetwork.org/genewiki point to the same URL.
- left-aligns both the wiki search page and wiki edit page:

genewiki Edit Page:

![image](https://github.com/user-attachments/assets/a30ec98f-b22f-4fd5-adaf-369db7dc942c)


genewiki Search Page:

![image](https://github.com/user-attachments/assets/8f0723ae-5971-41ee-9be0-25af4b2f20a7)
