### PR TITLE
Improve Group Page Error Handling and Styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ wqflask/output/*
 wqflask/wqflask/static/output/*
 wqflask/.coverage
 wqflask/coverage_html_report
+.aider*

--- a/gn2/wqflask/oauth2/request_utils.py
+++ b/gn2/wqflask/oauth2/request_utils.py
@@ -46,10 +46,14 @@ def process_error(error: Response,
     if error.status_code in range(400, 500):
         try:
             err = error.json()
-            potential_keys = [key for key in err.keys() if key.startswith("error")]
-            msg = f"{error.reason}"
-            if potential_keys:
-                msg = " ; ".join([f"{k}: {err[k]}" for k in potential_keys])
+            # Handle the specific NotFoundError for group membership
+            if "error-trace" in err and "User is not a member of any group" in err["error-trace"]:
+                msg = "You are not currently a member of any group. Please contact an administrator."
+            else:
+                potential_keys = [key for key in err.keys() if key.startswith("error")]
+                msg = f"{error.reason}"
+                if potential_keys:
+                    msg = " ; ".join([f"{k}: {err[k]}" for k in potential_keys])
         except simplejson.errors.JSONDecodeError as _jde:
             msg = message
         return {

--- a/gn2/wqflask/oauth2/request_utils.py
+++ b/gn2/wqflask/oauth2/request_utils.py
@@ -84,8 +84,8 @@ def handle_error(redirect_uri: Optional[str] = None, **kwargs):
               "alert-danger")
         if "response_handlers" in kwargs:
             for handler in kwargs["response_handlers"]:
-                handler(response)
-        if redirect:
+                handler(error)
+        if redirect_uri:
             return redirect(url_for(redirect_uri, **kwargs))
 
     return __handler__

--- a/gn2/wqflask/templates/oauth2/group.html
+++ b/gn2/wqflask/templates/oauth2/group.html
@@ -9,7 +9,7 @@
   {{flash_me()}}
 
   {%if group_error is defined%}
-  <div class="row" style="text-align:center;line-height:5em;">
+  <div class="row" style="text-align:left;line-height:5em;">
     {{display_error("Group", group_error)}}
   </div>
   {%else%}


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->
This PR improves error handling and styling in the group membership pages:

- Improves user-friendly error messages for the group membership
- Fixes undefined variables in error handling function
- Updates .gitignore to exclude .aider* files
- Left aligns error text in "group not found template".

Before:

![image](https://github.com/user-attachments/assets/2ed4b899-424f-47ef-99a1-f97fae398e11)

After:

![image](https://github.com/user-attachments/assets/4697dc0e-37c7-4502-8d07-b4e0440697c6)
