### PR TITLE
Restore sanity after guix upgrade 20250226

### DIFF
--- a/gn2/default_settings.py
+++ b/gn2/default_settings.py
@@ -23,6 +23,7 @@
 
 import os
 import sys
+import hashlib
 
 GN_VERSION = "3.12-rc1" # sync up with GN2
 
@@ -119,9 +120,18 @@ OAUTH2_CLIENT_SECRET="yadabadaboo"
 AUTH_SERVER_SSL_PUBLIC_KEY = "/absolute/path/to/ssl_public_key.pem"
 SSL_PRIVATE_KEY = "/absolute/path/to/ssl-private-key.pem"
 
-SESSION_TYPE = "redis"
 SESSION_PERMANENT = True
 SESSION_USE_SIGNER = True
+SESSION_TYPE = "cachelib"
+## --- Settings for CacheLib session type --- ##
+## --- These are on flask-session config variables --- ##
+## --- https://cachelib.readthedocs.io/en/stable/file/ --- ##
+SESSION_FILESYSTEM_CACHE_PATH = "./flask_session"
+SESSION_FILESYSTEM_CACHE_THRESHOLD = 500
+SESSION_FILESYSTEM_CACHE_TIMEOUT = 300
+SESSION_FILESYSTEM_CACHE_MODE = 0o600
+SESSION_FILESYSTEM_CACHE_HASH_METHOD = hashlib.md5
+## --- END: Settings for CacheLib session type --- ##
 
 
 # BEGIN: JSON WEB KEYS #####

--- a/gn2/wqflask/__init__.py
+++ b/gn2/wqflask/__init__.py
@@ -13,6 +13,7 @@ import redis
 import jinja2
 from flask_session import Session
 from authlib.jose import JsonWebKey
+from cachelib import FileSystemCache
 from flask import g, Flask, flash, session, url_for, redirect, current_app
 
 
@@ -91,7 +92,10 @@ app = Flask(__name__)
 # Note no longer use the badly named WQFLASK_OVERRIDES (nyi)
 app.config.from_object('gn2.default_settings')
 app.config.from_envvar('GN2_SETTINGS')
-app.config["SESSION_REDIS"] = redis.from_url(app.config["REDIS_URL"])
+app.config["SESSION_CACHELIB"] = FileSystemCache(
+    cache_dir=Path(app.config["SESSION_FILESYSTEM_CACHE_PATH"]).absolute(),
+    threshold=int(app.config["SESSION_FILESYSTEM_CACHE_THRESHOLD"]),
+    default_timeout=int(app.config["SESSION_FILESYSTEM_CACHE_TIMEOUT"]))
 app.config['TEMPLATES_AUTO_RELOAD'] = True
 # BEGIN: SECRETS -- Should be the last of the settings to load
 secrets_file = Path(app.config.get("GN2_SECRETS", "")).absolute()

--- a/gn2/wqflask/pbkdf2.py
+++ b/gn2/wqflask/pbkdf2.py
@@ -1,6 +1,5 @@
+import hmac
 import hashlib
-
-from werkzeug.security import safe_str_cmp as ssc
 
 # Replace this because it just wraps around Python3's internal
 # functions. Added this during migration.
@@ -19,4 +18,9 @@ def pbkdf2_hex(data, salt, iterations=1000, keylen=24, hashfunc="sha1"):
 
 
 def safe_str_cmp(a, b):
-    return ssc(a, b)
+    def __str_to_bytes__(value):
+        if isinstance(value, str):
+            return value.encode("utf8")
+        return value
+
+    return hmac.compare_digest(__str_to_bytes__(a), __str_to_bytes(b))


### PR DESCRIPTION
#### Description
<!--Brief description of the PR. What does this PR do? -->

Werkzeug removed the `safe_str_cmp` function, so we replace it with a `hmac` equivalent.

We also move from using Redis for session storage (for flask-session) to using a file-system cache.