### PR TITLE
Genewiki UI updates

### DIFF
--- a/gn2/wqflask/templates/wiki/edit_wiki.html
+++ b/gn2/wqflask/templates/wiki/edit_wiki.html
@@ -35,20 +35,6 @@
                         </div>
                     {% endif %}
                     <div class="form-group">
-                        <label for="species" class="col-sm-2">Species:</label>
-                        <select name="species" id="species">
-			    {% if not content.species %}
- 			        {% set selected = "mouse" %}
-			    {% else %}
-			        {% set selected = content.species %}
-			    {% endif %}
-                            {% for name, species_name in species_dict.items() %}
-  			        <option value="{{ name }}" {% if name == selected %}selected="selected"{% endif %}>{{ species_name }}</option>
-			    {% endfor %}
-        		    <option value="no specific species">no specific species</option>
-                        </select>
-                    </div>
-                    <div class="form-group">
                         <label for="pubmed_ids" class="col-sm-2">PubMed IDS:</label>
                         <input type="text"
                                name="pubmed_ids"
@@ -84,12 +70,26 @@
                         <input type="text" name="initial" value="{{ content["initial"] }}" />
                         (optional user or project code or your initials)
                     </div>
-                    <div class="form-group wiki-btns">
+		    <div class="form-group">
+                        <label for="species" class="col-sm-2">Species:</label>
+                        <select name="species" id="species">
+			    {% if not content.species %}
+  			        {% set selected = "no specific species" %}
+			    {% else %}
+			        {% set selected = content.species %}
+			    {% endif %}
+                            {% for name, species_name in species_dict.items() %}
+  			        <option value="{{ name }}" {% if name == selected %}selected="selected"{% endif %}>{{ species_name }}</option>
+			    {% endfor %}
+                        </select>
+			(optional)
+		    </div>
+		    <div class="form-group wiki-btns">
                         <button type="submit" name="submit" class="btn btn-lg btn-primary">
 			    Submit
                         </button>
                         <button type="reset"
-                                name="rest"
+                                name="reset"
                                 class="btn btn-lg btn-secondary"
                                 onClick="window.location.reload();">Reset</button>
                     </div>

--- a/gn2/wqflask/templates/wiki/edit_wiki.html
+++ b/gn2/wqflask/templates/wiki/edit_wiki.html
@@ -1,10 +1,23 @@
 {% extends "index_page.html" %}
 {% block css %}
-    <style>
+<style>
+        .rif-form {
+            margin-left: 2em;
+            max-width: 100em;
+            width: fit-content;
+        }
+        #char-count {
+            font-weight: bold;
+            display: block;
+            width: 100%;
+            text-align: right;
+            padding-right: 23px;
+            margin-bottom: 1em;
+            margin-top: -1.5rem;
+        }
         .wiki-btns {
             margin-top: 5em;
         }
-
         .wiki-btns button:first-child {
             margin-right: 1em;
             margin-left: 1em;
@@ -16,7 +29,7 @@
     {% set has_previous_versions = content|length > 1 %}
     <div class="container">
         <div class="row">
-            <div class="col-md-12">
+            <div class="rif-form">
                 <h1>
                     {% if not has_previous_versions %}
                         Add GeneWiki Entry
@@ -33,7 +46,12 @@
                             <label for="reason" class="col-sm-2">Reason for Modification:</label>
                             <input type="text" name="reason" size=45 maxlength=100 required>
                         </div>
-                    {% endif %}
+		    {% endif %}
+                    <div class="form-group">
+                        <label for="comment" class="col-sm-2">Text:</label>
+                        <textarea name="comment" id="textbox" rows=13 cols=60 placeholder="Enter your GeneWiki entry here" required>{{ content["comment"] }}</textarea>
+                    </div>
+		    <span id="char-count">512/512</span>
                     <div class="form-group">
                         <label for="pubmed_ids" class="col-sm-2">PubMed IDS:</label>
                         <input type="text"
@@ -56,10 +74,6 @@
                             <input type="text" name="web_url" value="http://" size=50 maxlength=255>
                         {% endif %}
                         (optional)
-                    </div>
-                    <div class="form-group">
-                        <label for="comment" class="col-sm-2">Text:</label>
-                        <textarea name="comment" rows=5 cols=60 required>{{ content["comment"] }}</textarea>
                     </div>
                     <div class="form-group">
                         <label for="email" class="col-sm-2">Email:</label>
@@ -97,4 +111,24 @@
             </div>
         </div>
     </div>
+{% endblock %}
+
+
+{% block js %}
+<script type="text/javascript">
+ let textArea = document.getElementById("textbox");
+ let characterCounter = document.getElementById("char-count");
+ const maxNumOfChars = 512;
+ const countCharacters = () => {
+	 let numOfEnteredChars = textArea.value.length;
+	 let counter = maxNumOfChars - numOfEnteredChars;
+	 if (counter < 0) {
+	     characterCounter.style.color = "red";
+	 } else {
+	     characterCounter.style.color = "black";
+	 }
+	 characterCounter.textContent = counter + "/512";
+ };
+ textArea.addEventListener("input", countCharacters);
+</script>
 {% endblock %}

--- a/gn2/wqflask/templates/wiki/edit_wiki.html
+++ b/gn2/wqflask/templates/wiki/edit_wiki.html
@@ -84,32 +84,6 @@
                         <input type="text" name="initial" value="{{ content["initial"] }}" />
                         (optional user or project code or your initials)
                     </div>
-                    <div class="form-group">
-                        <label class="col-sm-2">
-                            Category of Gene
-                            <br>
-                            (Please select one or
-                            <br>
-                            many categories):
-                        </label>
-                        <div class="col-sm-10">
-                            {% for group in grouped_categories %}
-                                <div class="row">
-                                    {% for cat in group %}
-                                        <label class="checkbox-inline col-sm-3">
-                                            {% if cat in content["categories"] %}
-                                                <input checked type="checkbox" name="genecategory" value="{{ cat }}">
-                                                {{ cat }}
-                                            {% else %}
-                                                <input type="checkbox" name="genecategory" value="{{ cat }} ">
-                                                {{ cat }}
-                                            {% endif %}
-                                        </label>
-                                    {% endfor %}
-                                </div>
-                            {% endfor %}
-                        </div>
-                    </div>
                     <div class="form-group wiki-btns">
                         <button type="submit" name="submit" class="btn btn-lg btn-primary">
 			    Submit

--- a/gn2/wqflask/templates/wiki/edit_wiki.html
+++ b/gn2/wqflask/templates/wiki/edit_wiki.html
@@ -102,10 +102,6 @@
                         <button type="submit" name="submit" class="btn btn-lg btn-primary">
 			    Submit
                         </button>
-                        <button type="reset"
-                                name="reset"
-                                class="btn btn-lg btn-secondary"
-                                onClick="window.location.reload();">Reset</button>
                     </div>
                 </form>
             </div>

--- a/gn2/wqflask/views.py
+++ b/gn2/wqflask/views.py
@@ -1642,6 +1642,7 @@ def edit_wiki(comment_id: Optional[int]):
         )
         species_dict_resp.raise_for_status()
         species_dict = species_dict_resp.json()
+        species_dict["no specific species"] = "no specific species"
 
         session_email = session_info()["user"]["email"]
         return render_template(

--- a/gn2/wqflask/views.py
+++ b/gn2/wqflask/views.py
@@ -1643,21 +1643,11 @@ def edit_wiki(comment_id: Optional[int]):
         species_dict_resp.raise_for_status()
         species_dict = species_dict_resp.json()
 
-        categories_resp = requests.get(
-            urljoin(GN3_LOCAL_URL, "/api/metadata/wiki/categories")
-        )
-        categories_resp.raise_for_status()
-        categories = list(categories_resp.json().keys())
-        grouped_categories = [
-            categories[i: i + 3] for i in range(0, len(categories), 3)
-        ]
-
         session_email = session_info()["user"]["email"]
         return render_template(
             "wiki/edit_wiki.html",
             content=last_wiki_content,
             species_dict=species_dict,
-            grouped_categories=grouped_categories,
             session_email=session_email,
         )
     if request.method == "POST":


### PR DESCRIPTION
# Description
This PR cleans up the wiki editing form to make it more user-friendly. I’ve ditched gene categories and the reset button to cut clutter, toned down the species fields (made it optional), moved the text input to the top, and added a character count for real-time feedback:

![Uploading image.png…]()
