### PR TITLE
Refactor: Replace TMPDIR with CACHEDIR for metadata and text files

### DIFF
--- a/gn2/wqflask/correlation/pre_computes.py
+++ b/gn2/wqflask/correlation/pre_computes.py
@@ -9,16 +9,18 @@ import pickle
 from pathlib import Path
 
 from gn2.base.data_set import query_table_timestamp
-from gn2.base.webqtlConfig import TEXTDIR
-from gn2.base.webqtlConfig import TMPDIR
+from gn2.base.webqtlConfig import CACHEDIR
 
 from json.decoder import JSONDecodeError
+from gn2.utility.tools import  assert_writable_dir
+
+assert_writable_dir(CACHEDIR)
 
 def cache_trait_metadata(dataset_name, data):
 
 
     try:
-        with lmdb.open(os.path.join(TMPDIR,f"metadata_{dataset_name}"),map_size=20971520) as env:
+        with lmdb.open(os.path.join(CACHEDIR, f"metadata_{dataset_name}"),map_size=20971520) as env:
             with  env.begin(write=True) as  txn:
                 data_bytes = pickle.dumps(data)
                 txn.put(f"{dataset_name}".encode(), data_bytes)
@@ -31,7 +33,7 @@ def cache_trait_metadata(dataset_name, data):
 
 def read_trait_metadata(dataset_name):
     try:
-        with lmdb.open(os.path.join(TMPDIR,f"metadata_{dataset_name}"),
+        with lmdb.open(os.path.join(CACHEDIR, f"metadata_{dataset_name}"),
             readonly=True, lock=False) as env:
             with env.begin() as txn:
                 db_name = txn.get(dataset_name.encode())
@@ -44,7 +46,7 @@ def fetch_all_cached_metadata(dataset_name):
     """in a gvein dataset fetch all the traits metadata"""
     file_name = generate_filename(dataset_name, suffix="metadata")
 
-    file_path = Path(TMPDIR, file_name)
+    file_path = Path(CACHEDIR, file_name)
 
     try:
         with open(file_path, "r+") as file_handler:
@@ -84,7 +86,7 @@ def generate_filename(*args, suffix="", file_ext="json"):
 
 
 
-def fetch_text_file(dataset_name, conn, text_dir=TMPDIR):
+def fetch_text_file(dataset_name, conn, text_dir=CACHEDIR):
     """fetch textfiles with strain vals if exists"""
 
     def __file_scanner__(text_dir, target_file):
@@ -98,9 +100,7 @@ def fetch_text_file(dataset_name, conn, text_dir=TMPDIR):
         results = cursor.fetchone()
     if results:
         try:
-            # checks first for recently generated textfiles if not use gn1 datamatrix
-
-            return __file_scanner__(text_dir, results[0]) or __file_scanner__(TEXTDIR, results[0])
+            return __file_scanner__(text_dir, results[0])
 
         except Exception:
             pass
@@ -126,7 +126,7 @@ def read_text_file(sample_dict, file_path):
         return (sample_vals, [[line[i] for i in _posit] for line in csv_reader])
 
 
-def write_db_to_textfile(db_name, conn, text_dir=TMPDIR):
+def write_db_to_textfile(db_name, conn, text_dir=CACHEDIR):
 
     def __sanitise_filename__(filename):
         ttable = str.maketrans({" ": "_", "/": "_", "\\": "_"})

--- a/scripts/generate_correlation_cache.py
+++ b/scripts/generate_correlation_cache.py
@@ -1,0 +1,39 @@
+"""This script file reads all Probeset Dataset and caches the data in the CACHEDIR"""
+
+import logging
+from gn2.wqflask.correlation.pre_computes import write_db_to_textfile
+from gn2.base.webqtlConfig import CACHEDIR
+from gn_libs.mysqldb import database_connection
+from gn2.utility.tools import SQL_URI, assert_writable_dir
+
+# Setup logging
+logging.basicConfig(
+    filename="write_db_to_textfile.log",
+    filemode="a",
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+assert_writable_dir(CACHEDIR)
+
+def main():
+    logging.info("Starting database text file export...")
+
+    with database_connection(SQL_URI) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT Name FROM ProbeSetFreeze")
+            db_names = cursor.fetchall()
+
+        for (db_name,) in db_names:
+            db_name = db_name.strip()
+            logging.info(f"Processing {db_name}...")
+            try:
+                write_db_to_textfile(db_name, conn, text_dir=CACHEDIR)
+                logging.info(f"Finished {db_name}")
+            except Exception as e:
+                logging.error(f"Error processing {db_name}: {e}", exc_info=True)
+
+    logging.info("All processing complete.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

*  Updated all TMPDIR references to use CACHEDIR.
* Added assert_writable_dir(CACHEDIR) to validate cache directory at runtime.
* Removed fallback to GN1 TEXTDIR in fetch_text_file.
