### PR TITLE
Add a feature-switch check function to jinja templates

### DIFF
--- a/gn2/wqflask/__init__.py
+++ b/gn2/wqflask/__init__.py
@@ -114,6 +114,7 @@ app.jinja_env.globals.update(
     authserver_authorise_uri=authserver_authorise_uri,
     user_details=user_details,
     num_collections=numcoll,
+    is_test_feature_enabled=lambda:app.config.get("TEST_FEATURE_SWITCH", False),
     datetime=datetime)
 
 


### PR DESCRIPTION
# Description

This flag disables UI features not ready for production. It defaults to False, requiring no changes to the production container.

Example Use Case:
I want a user to test out deletion without this feature in production.   This flag only allows certain UI elements to be visible in CD and the local test environment only.